### PR TITLE
Improve Boxed_Number

### DIFF
--- a/include/chaiscript/dispatchkit/boxed_number.hpp
+++ b/include/chaiscript/dispatchkit/boxed_number.hpp
@@ -303,18 +303,8 @@ namespace chaiscript
       }
 
       Boxed_Number(const Boxed_Value &v)
-        : bv(v)
       {
-        const Type_Info &inp_ = v.get_type_info();
-        if (inp_ == typeid(bool))
-        {
-          throw boost::bad_any_cast();
-        }
-
-        if (!inp_.is_arithmetic())
-        {
-          throw boost::bad_any_cast();
-        }
+        operator=(v);
       }
 
 
@@ -381,6 +371,24 @@ namespace chaiscript
       Boxed_Number operator&=(const Boxed_Number &t_rhs)
       {
         return oper(Operators::assign_bitwise_and, this->bv, t_rhs.bv);
+      }
+
+      Boxed_Number operator=(const Boxed_Value &v)
+      {
+        bv = v;
+
+        const Type_Info &inp_ = v.get_type_info();
+        if (inp_ == typeid(bool))
+        {
+          throw boost::bad_any_cast();
+        }
+
+        if (!inp_.is_arithmetic())
+        {
+          throw boost::bad_any_cast();
+        }
+
+        return *this;
       }
 
       Boxed_Number operator=(const Boxed_Number &t_rhs) const


### PR DESCRIPTION
The default constructor increases the usability of the Boxed_Number class.
One can assign a value to it later by assigning a Boxed_Number or Boxed_Value to it.

All unittests passed.
