### PR TITLE
Fixes build issue for Boxed_Value

### DIFF
--- a/include/chaiscript/dispatchkit/dynamic_cast_conversion.hpp
+++ b/include/chaiscript/dispatchkit/dynamic_cast_conversion.hpp
@@ -7,6 +7,9 @@
 #ifndef CHAISCRIPT_DYNAMIC_CAST_CONVERSION_HPP_
 #define CHAISCRIPT_DYNAMIC_CAST_CONVERSION_HPP_
 
+#include <memory>
+#include <set>
+
 #include "type_info.hpp"
 #include "boxed_value.hpp"
 #include "boxed_cast_helper.hpp"


### PR DESCRIPTION
This fixes the problem, that one has to include chaiscript.hpp to build
compilation units, which only use Boxed_Value and boxed_cast.
You can now just include boxed_cast.hpp. This decreases build time
significant.
