### PR TITLE
Make main.cpp compile when readline is available

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,18 @@ char *mystrdup (const char *s) {
     return d;                            // Return the new string
 }
 
+char* readline(const char* p)
+{
+  std::string retval;
+  std::cout << p ;
+  std::getline(std::cin, retval);
+  return std::cin.eof() ? NULL : mystrdup(retval.c_str());
+}
+
+void add_history(const char*){}
+void using_history(){}
+#endif
+
 void *cast_module_symbol(std::string (*t_path)())
 {
   union cast_union
@@ -100,19 +112,6 @@ std::string default_search_path()
   }
 #endif
 }
-
-
-char* readline(const char* p)
-{
-  std::string retval;
-  std::cout << p ;
-  std::getline(std::cin, retval);
-  return std::cin.eof() ? NULL : mystrdup(retval.c_str());
-}
-
-void add_history(const char*){}
-void using_history(){}
-#endif
 
 void help(int n) {
   if ( n >= 0 ) {


### PR DESCRIPTION
Some of the symbols were defined in preprocessor conditionals and thus weren't available when the readline branch was picked. This seems to fix the build, any hints on running tests to confirm whether or not I have broken everything?
