### PR TITLE
force no unicode in search parth windows

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,9 +50,9 @@ void *cast_module_symbol(std::string (*t_path)())
 
 std::string default_search_path()
 {
-#ifdef CHAISCRIPT_WINDOWS
-  TCHAR path[2048];
-  int size = GetModuleFileName(0, path, sizeof(path)-1);
+#ifdef CHAISCRIPT_WINDOWS  // force no unicode
+  CHAR path[4096];
+  int size = GetModuleFileNameA(0, path, sizeof(path)-1);
 
   std::string exepath(path, size);
 


### PR DESCRIPTION
Quick fix when compiling on windows in Unicode mode.
