### PR TITLE
Divide by zero protection

### DIFF
--- a/include/chaiscript/dispatchkit/bootstrap.hpp
+++ b/include/chaiscript/dispatchkit/bootstrap.hpp
@@ -396,10 +396,9 @@ namespace chaiscript
 
         m->add(user_type<std::runtime_error>(), "runtime_error");
         m->add(chaiscript::base_class<std::exception, std::runtime_error>());
- 
 
         m->add(constructor<std::runtime_error (const std::string &)>(), "runtime_error");
-        m->add(fun(std::function<std::string (const std::runtime_error &)>(&what)), "what");     
+        m->add(fun(std::function<std::string (const std::runtime_error &)>(&what)), "what");
 
         m->add(user_type<dispatch::Dynamic_Object>(), "Dynamic_Object");
         m->add(constructor<dispatch::Dynamic_Object (const std::string &)>(), "Dynamic_Object");
@@ -487,7 +486,12 @@ namespace chaiscript
         m->add(chaiscript::fun(&has_parse_tree), "has_parse_tree");
         m->add(chaiscript::fun(&get_parse_tree), "get_parse_tree");
 
-        m->add(chaiscript::base_class<std::exception, chaiscript::exception::eval_error>());
+        m->add(chaiscript::user_type<chaiscript::exception::eval_error>("eval_error"));
+        m->add(chaiscript::base_class<std::runtime_error, chaiscript::exception::eval_error>());
+
+        m->add(chaiscript::user_type<chaiscript::exception::arithmetic_error>("arithmetic_error"));
+        m->add(chaiscript::base_class<std::runtime_error, chaiscript::exception::arithmetic_error>());
+
 
 //        chaiscript::bootstrap::standard_library::vector_type<std::vector<std::shared_ptr<chaiscript::AST_Node> > >("AST_NodeVector", m);
 

--- a/include/chaiscript/dispatchkit/bootstrap.hpp
+++ b/include/chaiscript/dispatchkit/bootstrap.hpp
@@ -486,10 +486,10 @@ namespace chaiscript
         m->add(chaiscript::fun(&has_parse_tree), "has_parse_tree");
         m->add(chaiscript::fun(&get_parse_tree), "get_parse_tree");
 
-        m->add(chaiscript::user_type<chaiscript::exception::eval_error>("eval_error"));
+        m->add(chaiscript::user_type<chaiscript::exception::eval_error>(), "eval_error");
         m->add(chaiscript::base_class<std::runtime_error, chaiscript::exception::eval_error>());
 
-        m->add(chaiscript::user_type<chaiscript::exception::arithmetic_error>("arithmetic_error"));
+        m->add(chaiscript::user_type<chaiscript::exception::arithmetic_error>(), "arithmetic_error");
         m->add(chaiscript::base_class<std::runtime_error, chaiscript::exception::arithmetic_error>());
 
 

--- a/include/chaiscript/dispatchkit/boxed_number.hpp
+++ b/include/chaiscript/dispatchkit/boxed_number.hpp
@@ -53,7 +53,9 @@ namespace chaiscript
       template<typename T>
       static void check_divide_by_zero(T t)
       {
-        if(std::is_arithmetic<T>::value) if(t==0) throw chaiscript::exception::arithmetic_error("divide by zero");
+        if(std::is_integral<T>::value && std::is_arithmetic<T>::value && t==0) {
+          throw chaiscript::exception::arithmetic_error("divide by zero");
+        }
       }
 #else
       template<typename T>

--- a/include/chaiscript/dispatchkit/boxed_number.hpp
+++ b/include/chaiscript/dispatchkit/boxed_number.hpp
@@ -49,32 +49,20 @@ namespace chaiscript
   class Boxed_Number
   {
     private:
-#ifndef CHAISCRIPT_NO_PROTECT_DIVIDEBYZERO
       template<typename T>
-      static void check_divide_by_zero(T t)
+      static void check_divide_by_zero(T t, typename std::enable_if<std::is_integral<T>::value>::type* = 0)
       {
-
-#ifdef CHAISCRIPT_MSVC
-        // MSVC complains that this expression is both constant and the value t is unused
-        // in the cases of integral expressions. Seems a bit overzealous to me, the parameter
-        // is only unreferenced because they are eliminating the dead code.
-#pragma warning(push)
-#pragma warning(disable : 4100 4127)
-#endif
-        if(std::is_integral<T>::value && std::is_arithmetic<T>::value && t==0) {
+#ifndef CHAISCRIPT_NO_PROTECT_DIVIDEBYZERO
+        if (t == 0) {
           throw chaiscript::exception::arithmetic_error("divide by zero");
         }
-#ifdef CHAISCRIPT_MSVC
-#pragma warning(pop)
 #endif
-
       }
-#else
+
       template<typename T>
-      static void check_divide_by_zero(T)
+      static void check_divide_by_zero(T, typename std::enable_if<std::is_floating_point<T>::value>::type* = 0)
       {
       }
-#endif
 
       struct boolean
       {

--- a/include/chaiscript/dispatchkit/boxed_number.hpp
+++ b/include/chaiscript/dispatchkit/boxed_number.hpp
@@ -28,10 +28,7 @@ namespace chaiscript
   {
     struct arithmetic_error : public std::runtime_error
     {
-      std::string reason;
-
-      arithmetic_error(const std::string& reason) : std::runtime_error(std::string("Arithmetic error: ").append(reason)), reason(reason) {}
-      arithmetic_error(const char* reason) : std::runtime_error(std::string("Arithmetic error: ").append(reason)), reason(reason) {}
+      arithmetic_error(const std::string& reason) : std::runtime_error("Arithmetic error: " + reason) {}
       virtual ~arithmetic_error() {}
     };
 #define CHAISCRIPT_ARITHMETIC_CHECKDIVIDEBYZERO(T, n) if(std::is_arithmetic<T>::value) if(n==0) throw chaiscript::exception::arithmetic_error("divide by zero");

--- a/include/chaiscript/dispatchkit/boxed_number.hpp
+++ b/include/chaiscript/dispatchkit/boxed_number.hpp
@@ -29,7 +29,7 @@ namespace chaiscript
     struct arithmetic_error : public std::runtime_error
     {
       arithmetic_error(const std::string& reason) : std::runtime_error("Arithmetic error: " + reason) {}
-      virtual ~arithmetic_error() {}
+      virtual ~arithmetic_error() CHAISCRIPT_NOEXCEPT {}
     };
   }
 }

--- a/include/chaiscript/dispatchkit/boxed_number.hpp
+++ b/include/chaiscript/dispatchkit/boxed_number.hpp
@@ -49,7 +49,7 @@ namespace chaiscript
   class Boxed_Number
   {
     private:
-#ifdef CHAISCRIPT_PROTECT_DIVIDEBYZERO
+#ifndef CHAISCRIPT_NO_PROTECT_DIVIDEBYZERO
       template<typename T>
       static void check_divide_by_zero(T t)
       {

--- a/include/chaiscript/dispatchkit/boxed_number.hpp
+++ b/include/chaiscript/dispatchkit/boxed_number.hpp
@@ -24,18 +24,18 @@ class Type_Conversions;
 
 namespace chaiscript
 {
-	namespace exception
-	{
-		struct arithmetic_error : public std::runtime_error
-		{
-			std::string reason;
+  namespace exception
+  {
+    struct arithmetic_error : public std::runtime_error
+    {
+      std::string reason;
 
-			arithmetic_error(const std::string& reason) : std::runtime_error(std::string("Arithmetic error: ").append(reason)), reason(reason) {}
-			arithmetic_error(const char* reason) : std::runtime_error(std::string("Arithmetic error: ").append(reason)), reason(reason) {}
-			virtual ~arithmetic_error() {}
-		};
+      arithmetic_error(const std::string& reason) : std::runtime_error(std::string("Arithmetic error: ").append(reason)), reason(reason) {}
+      arithmetic_error(const char* reason) : std::runtime_error(std::string("Arithmetic error: ").append(reason)), reason(reason) {}
+      virtual ~arithmetic_error() {}
+    };
 #define CHAISCRIPT_ARITHMETIC_CHECKDIVIDEBYZERO(T, n) if(std::is_arithmetic<T>::value) if(n==0) throw chaiscript::exception::arithmetic_error("divide by zero");
-	}
+  }
 }
 
 namespace chaiscript 
@@ -105,10 +105,10 @@ namespace chaiscript
               t += u;
               break;
             case Operators::assign_quotient:
-            #ifdef CHAISCRIPT_PROTECT_DIVIDEBYZERO
-      			  CHAISCRIPT_ARITHMETIC_CHECKDIVIDEBYZERO(U, u)
-      		  #endif
-              t /= u;
+#ifdef CHAISCRIPT_PROTECT_DIVIDEBYZERO
+              CHAISCRIPT_ARITHMETIC_CHECKDIVIDEBYZERO(U, u)
+#endif
+                t /= u;
               break;
             case Operators::assign_difference:
               t -= u;
@@ -141,9 +141,9 @@ namespace chaiscript
               t >>= u;
               break;
             case Operators::assign_remainder:
-            #ifdef CHAISCRIPT_PROTECT_DIVIDEBYZERO
-      			  CHAISCRIPT_ARITHMETIC_CHECKDIVIDEBYZERO(U, u)
-      		  #endif
+#ifdef CHAISCRIPT_PROTECT_DIVIDEBYZERO
+              CHAISCRIPT_ARITHMETIC_CHECKDIVIDEBYZERO(U, u)
+#endif
               t %= u;
               break;
             case Operators::assign_bitwise_xor:
@@ -168,10 +168,10 @@ namespace chaiscript
             case Operators::shift_right:
               return const_var(t >> u);
             case Operators::remainder:
-            #ifdef CHAISCRIPT_PROTECT_DIVIDEBYZERO
-      			  CHAISCRIPT_ARITHMETIC_CHECKDIVIDEBYZERO(U, u)
-      		  #endif
-              return const_var(t % u);
+#ifdef CHAISCRIPT_PROTECT_DIVIDEBYZERO
+              CHAISCRIPT_ARITHMETIC_CHECKDIVIDEBYZERO(U, u)
+#endif
+                return const_var(t % u);
             case Operators::bitwise_and:
               return const_var(t & u);
             case Operators::bitwise_or:
@@ -196,10 +196,10 @@ namespace chaiscript
             case Operators::sum:
               return const_var(t + u);
             case Operators::quotient:
-            #ifdef CHAISCRIPT_PROTECT_DIVIDEBYZERO
-      			  CHAISCRIPT_ARITHMETIC_CHECKDIVIDEBYZERO(U, u)
-      		  #endif
-              return const_var(t / u);
+#ifdef CHAISCRIPT_PROTECT_DIVIDEBYZERO
+              CHAISCRIPT_ARITHMETIC_CHECKDIVIDEBYZERO(U, u)
+#endif
+                return const_var(t / u);
             case Operators::product:
               return const_var(t * u);
             case Operators::difference:

--- a/include/chaiscript/dispatchkit/boxed_number.hpp
+++ b/include/chaiscript/dispatchkit/boxed_number.hpp
@@ -53,9 +53,21 @@ namespace chaiscript
       template<typename T>
       static void check_divide_by_zero(T t)
       {
+
+#ifdef CHAISCRIPT_MSVC
+        // MSVC complains that this expression is both constant and the value t is unused
+        // in the cases of integral expressions. Seems a bit overzealous to me, the parameter
+        // is only unreferenced because they are eliminating the dead code.
+#pragma warning(push)
+#pragma warning(disable : 4100 4127)
+#endif
         if(std::is_integral<T>::value && std::is_arithmetic<T>::value && t==0) {
           throw chaiscript::exception::arithmetic_error("divide by zero");
         }
+#ifdef CHAISCRIPT_MSVC
+#pragma warning(pop)
+#endif
+
       }
 #else
       template<typename T>

--- a/include/chaiscript/language/chaiscript_eval.hpp
+++ b/include/chaiscript/language/chaiscript_eval.hpp
@@ -93,6 +93,8 @@ namespace chaiscript
               // If it's an arithmetic operation we want to short circuit dispatch
               try{
                 return Boxed_Number::do_oper(t_oper, t_lhs, t_rhs);
+              } catch (const chaiscript::exception::arithmetic_error &) {
+                throw;
               } catch (...) {
                 throw exception::eval_error("Error with numeric operator calling: " + t_oper_string);
               }

--- a/unittests/divide_by_zero_protection.chai
+++ b/unittests/divide_by_zero_protection.chai
@@ -1,0 +1,7 @@
+try {
+  3/0
+  assert_true(false); // should never get here
+} catch (e) {
+  assert_equal("Arithmetic error: divide by zero", e.what())
+}
+

--- a/unittests/divide_by_zero_protection.chai
+++ b/unittests/divide_by_zero_protection.chai
@@ -5,3 +5,5 @@ try {
   assert_equal("Arithmetic error: divide by zero", e.what())
 }
 
+assert_equal(3/0.0, Infinity)
+

--- a/unittests/future.chai
+++ b/unittests/future.chai
@@ -1,6 +1,6 @@
 var func = fun(){
   var ret = 0;
-  for (var i = 0; i < 1000000; ++i) {
+  for (var i = 0; i < 50000; ++i) {
     ret += i;
   }
   return ret;
@@ -9,9 +9,7 @@ var func = fun(){
 
 var fut1 := async(func);
 var fut2 := async(func);
-var fut3 := async(func);
-var fut4 := async(func);
 
 // simply executing without crashing is good enough for this test
 
-print(" ${fut1.get()} ${fut2.get()} ${fut3.get()} ${fut4.get()}")
+print(" ${fut1.get()} ${fut2.get()} ")


### PR DESCRIPTION
@lufinkey I've taken your divide by zero protection patches and gotten them ready for merging into ChaiScript.

I made the following changes:

1. Remove macros in favor of function template
2. Make divide by zero protection the default behavior
3. Limit protection to only integer types, floating point returns "Infinity"
4. Make sure the divide by zero is catchable inside the ChaiScript itself
5. Add some unit tests

I'll merge it shortly but thought you might want to see the changes.