### PR TITLE
Libcxx ubuntu 14 04

### DIFF
--- a/.decent_ci-Linux.yaml
+++ b/.decent_ci-Linux.yaml
@@ -4,6 +4,11 @@ compilers:
     skip_packaging: true
     cmake_extra_flags: -DUSE_LIBCXX:BOOL=OFF -DBUILD_SAMPLES:BOOL=ON -DBUILD_PACKAGE:BOOL=ON -DBUILD_TESTING:BOOL=ON
   - name: "clang"
+    build_tag: "LibC++"
+    version: "3.5"
+    skip_packaging: true
+    cmake_extra_flags: -DUSE_LIBCXX:BOOL=ON -DBUILD_SAMPLES:BOOL=ON -DBUILD_PACKAGE:BOOL=ON -DBUILD_TESTING:BOOL=ON
+  - name: "clang"
     build_tag: AddressSanitizer
     version: "3.5"
     skip_packaging: true

--- a/include/chaiscript/chaiscript_defines.hpp
+++ b/include/chaiscript/chaiscript_defines.hpp
@@ -15,6 +15,12 @@
 #endif
 #endif
 
+#include <vector>
+
+#if defined( _LIBCPP_VERSION )
+#define CHAISCRIPT_LIBCPP
+#endif
+
 #if defined(_WIN32) || defined(__CYGWIN__)
 #define CHAISCRIPT_WINDOWS
 #endif

--- a/include/chaiscript/dispatchkit/bootstrap.hpp
+++ b/include/chaiscript/dispatchkit/bootstrap.hpp
@@ -357,7 +357,9 @@ namespace chaiscript
       template<typename Function>
       static std::function<std::vector<Boxed_Value> (const dispatch::Proxy_Function_Base*)> return_boxed_value_vector(const Function &f)
       {
-        return std::bind(&do_return_boxed_value_vector<Function>, f, std::placeholders::_1);
+        return [f](const dispatch::Proxy_Function_Base *b) {
+          return do_return_boxed_value_vector(f, b);
+        };
       }
 
 

--- a/include/chaiscript/dispatchkit/bootstrap_stl.hpp
+++ b/include/chaiscript/dispatchkit/bootstrap_stl.hpp
@@ -247,7 +247,6 @@ namespace chaiscript
         {
           // cppcheck-suppress syntaxError
           typedef typename ContainerType::reference(ContainerType::*indexoper)(size_t);
-          typedef typename ContainerType::const_reference(ContainerType::*constindexoper)(size_t) const;
 
           //In the interest of runtime safety for the m, we prefer the at() method for [] access,
           //to throw an exception in an out of bounds condition.
@@ -255,8 +254,10 @@ namespace chaiscript
               fun(std::function<typename ContainerType::reference (ContainerType *, int)>
                 (std::mem_fn(static_cast<indexoper>(&ContainerType::at)))), "[]");
           m->add(
-              fun(std::function<typename ContainerType::const_reference (const ContainerType *, int)>
-                (std::mem_fn(static_cast<constindexoper>(&ContainerType::at)))), "[]");
+              fun<typename ContainerType::const_reference (const ContainerType &, int)>(
+                [](const ContainerType &c, int index) -> typename ContainerType::const_reference {
+                  return c.at(index);
+                }), "[]");
 
           return m;
         }

--- a/include/chaiscript/dispatchkit/bootstrap_stl.hpp
+++ b/include/chaiscript/dispatchkit/bootstrap_stl.hpp
@@ -254,9 +254,9 @@ namespace chaiscript
               fun(std::function<typename ContainerType::reference (ContainerType *, int)>
                 (std::mem_fn(static_cast<indexoper>(&ContainerType::at)))), "[]");
           m->add(
-              fun<typename ContainerType::const_reference (const ContainerType &, int)>(
-                [](const ContainerType &c, int index) -> typename ContainerType::const_reference {
-                  return c.at(index);
+              fun<typename ContainerType::const_reference (const ContainerType *, int)>(
+                [](const ContainerType *c, int index) -> typename ContainerType::const_reference {
+                  return c->at(index);
                 }), "[]");
 
           return m;

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -367,7 +367,13 @@ namespace chaiscript
               [this](const std::vector<Boxed_Value> &t_params) {
                 return m_engine.call_exists(t_params);
               })), "call_exists");
-      m_engine.add(fun<Boxed_Value (const dispatch::Proxy_Function_Base *, const std::vector<Boxed_Value> &)>(std::bind(&chaiscript::dispatch::Proxy_Function_Base::operator(), std::placeholders::_1, std::placeholders::_2, std::ref(m_engine.conversions()))), "call");
+
+//      m_engine.add(fun<Boxed_Value (const dispatch::Proxy_Function_Base *, const std::vector<Boxed_Value> &)>(std::bind(&chaiscript::dispatch::Proxy_Function_Base::operator(), std::placeholders::_1, std::placeholders::_2, std::ref(m_engine.conversions()))), "call");
+//
+      m_engine.add(fun<Boxed_Value (const dispatch::Proxy_Function_Base &, const std::vector<Boxed_Value> &)>(
+            [=](const dispatch::Proxy_Function_Base &t_fun, const std::vector<Boxed_Value> &t_params) {
+              return t_fun(t_params, this->m_engine.conversions());
+            }), "call");
 
       m_engine.add(fun(&chaiscript::detail::Dispatch_Engine::get_type_name, std::ref(m_engine)), "name");
 

--- a/include/chaiscript/language/chaiscript_eval.hpp
+++ b/include/chaiscript/language/chaiscript_eval.hpp
@@ -712,7 +712,7 @@ namespace chaiscript
 
               fpp.save_params(params);
 
-              std::string fun_name = [&](){
+              std::string fun_name = [&]()->std::string{
                 if ((this->children[i]->identifier == AST_Node_Type::Fun_Call) || (this->children[i]->identifier == AST_Node_Type::Array_Call)) {
                   return this->children[i]->children[0]->text;
                 }

--- a/include/chaiscript/language/chaiscript_parser.hpp
+++ b/include/chaiscript/language/chaiscript_parser.hpp
@@ -617,7 +617,7 @@ namespace chaiscript
         }
 
 
-        const size_t size = [&](){
+        const size_t size = [&]()->size_t{
           if (longlong_)
           {
             return sizeof(int64_t) * 8;
@@ -800,7 +800,7 @@ namespace chaiscript
           const auto prev_line = m_line;
           if (Id_()) {
             m_match_stack.push_back(std::make_shared<eval::Id_AST_Node>(
-                  [&](){
+                  [&]()->std::string{
                     if (*start == '`') {
                       //Id Literal
                       return std::string(start+1, m_input_pos-1);

--- a/samples/example.cpp
+++ b/samples/example.cpp
@@ -76,7 +76,7 @@ int main(int /*argc*/, char * /*argv*/[]) {
   chai.add(var(&system), "system");
 
   //Add a bound callback method
-  chai.add(fun(&System::add_callback, system), "add_callback_bound");
+  chai.add(fun(&System::add_callback, std::ref(system)), "add_callback_bound");
 
   //Register the two methods of the System structure.
   chai.add(fun(&System::add_callback), "add_callback");

--- a/unittests/multithreaded_test.cpp
+++ b/unittests/multithreaded_test.cpp
@@ -68,7 +68,9 @@ int main()
   std::vector<std::shared_ptr<std::thread> > threads;
 
   // Ensure at least two, but say only 7 on an 8 core processor
-  int num_threads = std::max(std::thread::hardware_concurrency() - 1, 2u);
+  int num_threads = std::max(static_cast<int>(std::thread::hardware_concurrency()) - 1, 2);
+
+  std::cout << "Num threads: " << num_threads << '\n';
 
   for (int i = 0; i < num_threads; ++i)
   {


### PR DESCRIPTION
Fixes all known issues with building / running on ubuntu 14.04 with clang 3.5 and libc++1. Had to work around broken type_traits implementations for const member functions in libc++1. Closes #171 