### PR TITLE
Added elapsed time helper to chai executable

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -249,13 +249,11 @@ void interactive(chaiscript::ChaiScript& chai)
   }
 }
 
-double getTimeInSeconds()
+double now()
 {
   using namespace std::chrono;
-  static time_point<high_resolution_clock> start = high_resolution_clock::now();
-
-  duration<double> elapsed_seconds = high_resolution_clock::now() - start;
-  return elapsed_seconds.count();
+  auto now = high_resolution_clock::now();
+  return duration_cast<duration<double>>(now.time_since_epoch()).count();
 }
 
 int main(int argc, char *argv[])
@@ -297,7 +295,7 @@ int main(int argc, char *argv[])
   chai.add(chaiscript::fun(&help), "help");
   chai.add(chaiscript::fun(&throws_exception), "throws_exception");
   chai.add(chaiscript::fun(&get_eval_error), "get_eval_error");
-  chai.add(chaiscript::fun(&getTimeInSeconds), "getTimeInSeconds");
+  chai.add(chaiscript::fun(&now), "now");
 
 
   for (int i = 0; i < argc; ++i) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -249,6 +249,15 @@ void interactive(chaiscript::ChaiScript& chai)
   }
 }
 
+double getTimeInSeconds()
+{
+  using namespace std::chrono;
+  static time_point<high_resolution_clock> start = high_resolution_clock::now();
+
+  duration<double> elapsed_seconds = high_resolution_clock::now() - start;
+  return elapsed_seconds.count();
+}
+
 int main(int argc, char *argv[])
 {
 
@@ -288,6 +297,8 @@ int main(int argc, char *argv[])
   chai.add(chaiscript::fun(&help), "help");
   chai.add(chaiscript::fun(&throws_exception), "throws_exception");
   chai.add(chaiscript::fun(&get_eval_error), "get_eval_error");
+  chai.add(chaiscript::fun(&getTimeInSeconds), "getTimeInSeconds");
+
 
   for (int i = 0; i < argc; ++i) {
     if ( i == 0 && argc > 1 ) {

--- a/unittests/performance.chai
+++ b/unittests/performance.chai
@@ -1,0 +1,13 @@
+var sum = 0.0
+var start = now()
+for (var i = 1; i <= 100000; ++i) {
+  if (i % 2 == 0) {
+    sum += 1.0 / i;
+  }
+  else {
+    sum += 1.0 / (double(i) * i);
+  }
+}
+var end = now()
+print("Elapsed time: " + to_string(end - start) + " sum: " + to_string(sum))
+assert_equal(to_string(sum), "6.9322")


### PR DESCRIPTION
Hi there -- just thought I'd throw this your way, in case you want to integrate it...  If not (or if you want me to change the function name), that's fine.

It's handy when doing benchmarking to have some elapsed time functionality built in to the `chai` app.