### PR TITLE
Update chaiscript_engine.hpp

### DIFF
--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -36,7 +36,9 @@
 #else
 #ifdef CHAISCRIPT_WINDOWS
 #define VC_EXTRA_LEAN
+#if !defined(WIN32_LEAN_AND_MEAN)
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #endif
 #endif


### PR DESCRIPTION
Work around in case WIN32_LEAN_AND_MEAN is already defined, removes warning message