### PR TITLE
String escape sequence bug fix

### DIFF
--- a/include/chaiscript/language/chaiscript_parser.hpp
+++ b/include/chaiscript/language/chaiscript_parser.hpp
@@ -961,6 +961,32 @@ namespace chaiscript
         }
 
         void parse(const char_type t_char, const int line, const int col, const std::string &filename) {
+          const bool is_octal_char = t_char >= '0' && t_char <= '7';
+
+          if (is_octal) {
+            if (is_octal_char) {
+              octal_matches.push_back(t_char);
+
+              if (octal_matches.size() == 3) {
+                process_octal();
+              }
+              return;
+            } else {
+              process_octal();
+            }
+          } else if (is_hex) {
+            const bool is_hex_char = (t_char >= '0' && t_char <= '9')
+                                  || (t_char >= 'a' && t_char <= 'f')
+                                  || (t_char >= 'A' && t_char <= 'F');
+
+            if (is_hex_char) {
+              hex_matches.push_back(t_char);
+              return;
+            } else {
+              process_hex();
+            }
+          }
+
           if (t_char == '\\') {
             if (is_escaped) {
               match.push_back('\\');
@@ -970,31 +996,7 @@ namespace chaiscript
             }
           } else {
             if (is_escaped) {
-              const bool is_octal_char = t_char >= '0' && t_char <= '7';
-
-              if (is_octal) {
-                if (is_octal_char) {
-                  octal_matches.push_back(t_char);
-
-                  if (octal_matches.size() == 3) {
-                    process_octal();
-                  }
-                } else {
-                  process_octal();
-                  match.push_back(t_char);
-                }
-              } else if (is_hex) {
-                const bool is_hex_char = (t_char >= '0' && t_char <= '9')
-                                      || (t_char >= 'a' && t_char <= 'f')
-                                      || (t_char >= 'A' && t_char <= 'F');
-
-                if (is_hex_char) {
-                  hex_matches.push_back(t_char);
-                } else {
-                  process_hex();
-                  match.push_back(t_char);
-                }
-              } else if (is_octal_char) {
+              if (is_octal_char) {
                 is_octal = true;
                 octal_matches.push_back(t_char);
               } else if (t_char == 'x') {

--- a/include/chaiscript/language/chaiscript_parser.hpp
+++ b/include/chaiscript/language/chaiscript_parser.hpp
@@ -981,6 +981,14 @@ namespace chaiscript
 
             if (is_hex_char) {
               hex_matches.push_back(t_char);
+
+              if (hex_matches.size() == 2*sizeof(char_type)) {
+                // This rule differs from the C/C++ standard, but ChaiScript
+                // does not offer the same workaround options, and having
+                // hexadecimal sequences longer than can fit into the char
+                // type is undefined behavior anyway.
+                process_hex();
+              }
               return;
             } else {
               process_hex();

--- a/unittests/hex_escapes.chai
+++ b/unittests/hex_escapes.chai
@@ -3,4 +3,5 @@ assert_equal("\x39", "9")
 assert_equal("\x039", "9")
 assert_equal("\x39g", "9g")
 assert_equal("b\x39g", "b9g")
+assert_equal("\x39\x38g", "98g")
 

--- a/unittests/hex_escapes.chai
+++ b/unittests/hex_escapes.chai
@@ -1,6 +1,6 @@
 
 assert_equal("\x39", "9")
-assert_equal("\x039", "9")
+assert_equal("\x39ec", "9ec")
 assert_equal("\x39g", "9g")
 assert_equal("b\x39g", "b9g")
 assert_equal("\x39\x38g", "98g")

--- a/unittests/octal_escapes.chai
+++ b/unittests/octal_escapes.chai
@@ -3,4 +3,5 @@ assert_equal("\71", "9")
 assert_equal("\071", "9")
 assert_equal("\71a", "9a")
 assert_equal("b\71a", "b9a")
+assert_equal("\71\70a", "98a")
 


### PR DESCRIPTION
During tests I notices that consecutive octal/hex escape sequences in strings lead to parsing errors (due to open octal/hex sequences not being finished whenever a '\' is encountered).
The second commit is a semantic change to limit the length of hex escape sequence to the maximum that makes sense for the char type used. Without this it's a real problem to have arbitrary text following after a hex escape sequence.