### PR TITLE
Fix some warnings in clang 3.7.1

### DIFF
--- a/include/chaiscript/dispatchkit/dispatchkit.hpp
+++ b/include/chaiscript/dispatchkit/dispatchkit.hpp
@@ -1446,7 +1446,7 @@ namespace chaiscript
         static typename Container::const_iterator find_keyed_value(const Container &t_c, const Key &t_key, const size_t t_hint)
           {
             if (t_c.size() > t_hint && t_c[t_hint].first == t_key) {
-              return t_c.begin() + t_hint;
+              return t_c.begin() + static_cast<long>(t_hint);
             } else {
               return find_keyed_value(t_c, t_key);
             }

--- a/include/chaiscript/dispatchkit/type_info.hpp
+++ b/include/chaiscript/dispatchkit/type_info.hpp
@@ -32,11 +32,11 @@ namespace chaiscript
       CHAISCRIPT_CONSTEXPR Type_Info(bool t_is_const, bool t_is_reference, bool t_is_pointer, bool t_is_void, 
           bool t_is_arithmetic, const std::type_info *t_ti, const std::type_info *t_bare_ti)
         : m_type_info(t_ti), m_bare_type_info(t_bare_ti),
-          m_flags((t_is_const << is_const_flag)
-                + (t_is_reference << is_reference_flag)
-                + (t_is_pointer << is_pointer_flag)
-                + (t_is_void << is_void_flag)
-                + (t_is_arithmetic << is_arithmetic_flag))
+          m_flags((static_cast<unsigned int>(t_is_const) << is_const_flag)
+                + (static_cast<unsigned int>(t_is_reference) << is_reference_flag)
+                + (static_cast<unsigned int>(t_is_pointer) << is_pointer_flag)
+                + (static_cast<unsigned int>(t_is_void) << is_void_flag)
+                + (static_cast<unsigned int>(t_is_arithmetic) << is_arithmetic_flag))
       {
       }
 

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -505,7 +505,7 @@ namespace chaiscript
 
         // Let's see if this is a link that we should expand
         std::vector<char> buf(2048);
-        const size_t pathlen = readlink(dllpath.c_str(), &buf.front(), buf.size());
+        const size_t pathlen = static_cast<size_t>(readlink(dllpath.c_str(), &buf.front(), buf.size()));
         if (pathlen > 0 && pathlen < buf.size())
         {
           dllpath = std::string(&buf.front(), pathlen);

--- a/include/chaiscript/language/chaiscript_parser.hpp
+++ b/include/chaiscript/language/chaiscript_parser.hpp
@@ -147,7 +147,7 @@ namespace chaiscript
         }
 
         size_t remaining() const {
-          return std::distance(m_pos, m_end);
+          return static_cast<size_t>(std::distance(m_pos, m_end));
         }
 
         char operator*() const {
@@ -2213,8 +2213,8 @@ namespace chaiscript
 
                 switch (m_operators[t_precedence]) {
                   case(AST_Node_Type::Ternary_Cond) :
-                    m_match_stack.erase(m_match_stack.begin() + m_match_stack.size() - 2,
-                        m_match_stack.begin() + m_match_stack.size() - 1);
+                    m_match_stack.erase(m_match_stack.begin() + static_cast<long>(m_match_stack.size()) - 2,
+                        m_match_stack.begin() + static_cast<long>(m_match_stack.size()) - 1);
                     if (Symbol(":")) {
                       if (!Operator(t_precedence+1)) {
                         throw exception::eval_error("Incomplete "
@@ -2239,7 +2239,7 @@ namespace chaiscript
                   case(AST_Node_Type::Bitwise_Or) :
                   case(AST_Node_Type::Comparison) :
                     assert(m_match_stack.size() > 1);
-                    m_match_stack.erase(m_match_stack.begin() + m_match_stack.size() - 2, m_match_stack.begin() + m_match_stack.size() - 1);
+                    m_match_stack.erase(m_match_stack.begin() + static_cast<long>(m_match_stack.size()) - 2, m_match_stack.begin() + static_cast<long>(m_match_stack.size()) - 1);
                     build_match<eval::Binary_Operator_AST_Node>(prev_stack_top, oper->text);
                     break;
 


### PR DESCRIPTION
The library was unusable for me since I have -Werror on. This pull request solves it for me.

