### PR TITLE
Pass Module by reference instead of shared ptr

### DIFF
--- a/include/chaiscript/chaiscript_stdlib.hpp
+++ b/include/chaiscript/chaiscript_stdlib.hpp
@@ -40,19 +40,20 @@ namespace chaiscript
       {
         using namespace bootstrap;
 
-        ModulePtr lib = Bootstrap::bootstrap();
+        auto lib = std::make_shared<Module>();
+        Bootstrap::bootstrap(*lib);
 
-        lib->add(standard_library::vector_type<std::vector<Boxed_Value> >("Vector"));
-        lib->add(standard_library::string_type<std::string>("string"));
-        lib->add(standard_library::map_type<std::map<std::string, Boxed_Value> >("Map"));
-        lib->add(standard_library::pair_type<std::pair<Boxed_Value, Boxed_Value > >("Pair"));
+        standard_library::vector_type<std::vector<Boxed_Value> >("Vector", *lib);
+        standard_library::string_type<std::string>("string", *lib);
+        standard_library::map_type<std::map<std::string, Boxed_Value> >("Map", *lib);
+        standard_library::pair_type<std::pair<Boxed_Value, Boxed_Value > >("Pair", *lib);
 
 #ifndef CHAISCRIPT_NO_THREADS
-        lib->add(standard_library::future_type<std::future<chaiscript::Boxed_Value>>("future"));
+        standard_library::future_type<std::future<chaiscript::Boxed_Value>>("future", *lib);
         lib->add(chaiscript::fun([](const std::function<chaiscript::Boxed_Value ()> &t_func){ return std::async(std::launch::async, t_func);}), "async");
 #endif
 
-        lib->add(json_wrap::library());
+        json_wrap::library(*lib);
 
         lib->eval(ChaiScript_Prelude::chaiscript_prelude() /*, "standard prelude"*/ );
 

--- a/include/chaiscript/dispatchkit/bootstrap.hpp
+++ b/include/chaiscript/dispatchkit/bootstrap.hpp
@@ -52,7 +52,7 @@ namespace chaiscript
     }
 
     template<typename T, typename = typename std::enable_if<std::is_array<T>::value>::type >
-      Module& array(const std::string &type, Module& m)
+      void array(const std::string &type, Module& m)
       {
         typedef typename std::remove_extent<T>::type ReturnType;
         const auto extent = std::extent<T>::value;
@@ -83,9 +83,6 @@ namespace chaiscript
               [extent](const T &) {
                 return extent;
               }), "size");
-
-
-        return m;
       }
 
     /// \brief Adds a copy constructor for the given type to the given Model
@@ -94,9 +91,9 @@ namespace chaiscript
     /// \tparam T The type to add a copy constructor for
     /// \returns The passed in Module
     template<typename T>
-    Module& copy_constructor(const std::string &type, Module& m)
+    void copy_constructor(const std::string &type, Module& m)
     {
-      return m.add(constructor<T (const T &)>(), type);
+      m.add(constructor<T (const T &)>(), type);
     }
 
     /// \brief Add all comparison operators for the templated type. Used during bootstrap, also available to users.
@@ -104,7 +101,7 @@ namespace chaiscript
     /// \param[in,out] m module to add comparison operators to
     /// \returns the passed in Module.
     template<typename T>
-    Module& opers_comparison(Module& m)
+    void opers_comparison(Module& m)
     {
       operators::equal<T>(m);
       operators::greater_than<T>(m);
@@ -112,7 +109,6 @@ namespace chaiscript
       operators::less_than<T>(m);
       operators::less_than_equal<T>(m);
       operators::not_equal<T>(m);
-      return m;
     }
 
 
@@ -125,11 +121,10 @@ namespace chaiscript
     /// \sa copy_constructor
     /// \sa constructor
     template<typename T>
-    Module& basic_constructors(const std::string &type, Module& m)
+    void basic_constructors(const std::string &type, Module& m)
     {
       m.add(constructor<T ()>(), type);
       copy_constructor<T>(type, m);
-      return m;
     }
 
     /// \brief Adds a constructor for a POD type 
@@ -137,9 +132,9 @@ namespace chaiscript
     /// \param[in] type The name of the type
     /// \param[in,out] m The Module to add the constructor to
     template<typename T>
-    Module& construct_pod(const std::string &type, Module& m)
+    void construct_pod(const std::string &type, Module& m)
     {
-      return m.add(fun(&detail::construct_pod<T>), type);
+      m.add(fun(&detail::construct_pod<T>), type);
     }
 
 
@@ -183,14 +178,13 @@ namespace chaiscript
     /// Add all common functions for a POD type. All operators, and
     /// common conversions
     template<typename T>
-    Module& bootstrap_pod_type(const std::string &name, Module& m)
+    void bootstrap_pod_type(const std::string &name, Module& m)
     {
       m.add(user_type<T>(), name);
       m.add(constructor<T()>(), name);
       construct_pod<T>(name, m);
 
       m.add(fun(&parse_string<T>), "to_" + name);
-      return m;
     }
 
 
@@ -402,7 +396,7 @@ namespace chaiscript
       /// \brief perform all common bootstrap functions for std::string, void and POD types
       /// \param[in,out] m Module to add bootstrapped functions to
       /// \returns passed in Module
-      static Module& bootstrap(Module& m)
+      static void bootstrap(Module& m)
       {
         m.add(user_type<void>(), "void");
         m.add(user_type<bool>(), "bool");
@@ -645,10 +639,6 @@ namespace chaiscript
             { {fun(&parser::ChaiScript_Parser::parse), "parse"},
               {fun(&parser::ChaiScript_Parser::ast), "ast"} }
             );
-
-
-
-        return m;
       }
     };
   }

--- a/include/chaiscript/dispatchkit/bootstrap.hpp
+++ b/include/chaiscript/dispatchkit/bootstrap.hpp
@@ -52,12 +52,12 @@ namespace chaiscript
     }
 
     template<typename T, typename = typename std::enable_if<std::is_array<T>::value>::type >
-      ModulePtr array(const std::string &type, ModulePtr m = std::make_shared<Module>())
+      Module& array(const std::string &type, Module& m)
       {
         typedef typename std::remove_extent<T>::type ReturnType;
         const auto extent = std::extent<T>::value;
-        m->add(user_type<T>(), type);
-        m->add(fun(
+        m.add(user_type<T>(), type);
+        m.add(fun(
               [extent](T& t, size_t index)->ReturnType &{
                 if (extent > 0 && index >= extent) {
                   throw std::range_error("Array index out of range. Received: " + std::to_string(index)  + " expected < " + std::to_string(extent));
@@ -68,7 +68,7 @@ namespace chaiscript
               ), "[]"
             );
 
-        m->add(fun(
+        m.add(fun(
               [extent](const T &t, size_t index)->const ReturnType &{
                 if (extent > 0 && index >= extent) {
                   throw std::range_error("Array index out of range. Received: " + std::to_string(index)  + " expected < " + std::to_string(extent));
@@ -79,7 +79,7 @@ namespace chaiscript
               ), "[]"
             );
 
-        m->add(fun(
+        m.add(fun(
               [extent](const T &) {
                 return extent;
               }), "size");
@@ -92,20 +92,19 @@ namespace chaiscript
     /// \param[in] type The name of the type. The copy constructor will be named "type".
     /// \param[in,out] m The Module to add the copy constructor to
     /// \tparam T The type to add a copy constructor for
-    /// \returns The passed in ModulePtr, or the newly constructed one if the default param is used
+    /// \returns The passed in Module
     template<typename T>
-    ModulePtr copy_constructor(const std::string &type, ModulePtr m = std::make_shared<Module>())
+    Module& copy_constructor(const std::string &type, Module& m)
     {
-      m->add(constructor<T (const T &)>(), type);
-      return m;
+      return m.add(constructor<T (const T &)>(), type);
     }
 
     /// \brief Add all comparison operators for the templated type. Used during bootstrap, also available to users.
     /// \tparam T Type to create comparison operators for
     /// \param[in,out] m module to add comparison operators to
-    /// \returns the passed in ModulePtr or the newly constructed one if the default params are used.
+    /// \returns the passed in Module.
     template<typename T>
-    ModulePtr opers_comparison(ModulePtr m = std::make_shared<Module>())
+    Module& opers_comparison(Module& m)
     {
       operators::equal<T>(m);
       operators::greater_than<T>(m);
@@ -122,13 +121,13 @@ namespace chaiscript
     /// \param[in] type The name of the type to add the constructors for.
     /// \param[in,out] m The Module to add the basic constructors to
     /// \tparam T Type to generate basic constructors for
-    /// \returns The passed in ModulePtr, or the newly constructed one if the default param is used
+    /// \returns The passed in Module
     /// \sa copy_constructor
     /// \sa constructor
     template<typename T>
-    ModulePtr basic_constructors(const std::string &type, ModulePtr m = std::make_shared<Module>())
+    Module& basic_constructors(const std::string &type, Module& m)
     {
-      m->add(constructor<T ()>(), type);
+      m.add(constructor<T ()>(), type);
       copy_constructor<T>(type, m);
       return m;
     }
@@ -138,10 +137,9 @@ namespace chaiscript
     /// \param[in] type The name of the type
     /// \param[in,out] m The Module to add the constructor to
     template<typename T>
-    ModulePtr construct_pod(const std::string &type, ModulePtr m = std::make_shared<Module>())
+    Module& construct_pod(const std::string &type, Module& m)
     {
-      m->add(fun(&detail::construct_pod<T>), type);
-      return m;
+      return m.add(fun(&detail::construct_pod<T>), type);
     }
 
 
@@ -185,13 +183,13 @@ namespace chaiscript
     /// Add all common functions for a POD type. All operators, and
     /// common conversions
     template<typename T>
-    ModulePtr bootstrap_pod_type(const std::string &name, ModulePtr m = std::make_shared<Module>())
+    Module& bootstrap_pod_type(const std::string &name, Module& m)
     {
-      m->add(user_type<T>(), name);
-      m->add(constructor<T()>(), name);
+      m.add(user_type<T>(), name);
+      m.add(constructor<T()>(), name);
       construct_pod<T>(name, m);
 
-      m->add(fun(&parse_string<T>), "to_" + name);
+      m.add(fun(&parse_string<T>), "to_" + name);
       return m;
     }
 
@@ -261,41 +259,41 @@ namespace chaiscript
 
 
       /// Add all arithmetic operators for PODs
-      static void opers_arithmetic_pod(ModulePtr m = std::make_shared<Module>())
+      static void opers_arithmetic_pod(Module& m)
       {
-        m->add(fun(&Boxed_Number::equals), "==");
-        m->add(fun(&Boxed_Number::less_than), "<");
-        m->add(fun(&Boxed_Number::greater_than), ">");
-        m->add(fun(&Boxed_Number::greater_than_equal), ">=");
-        m->add(fun(&Boxed_Number::less_than_equal), "<=");
-        m->add(fun(&Boxed_Number::not_equal), "!=");
+        m.add(fun(&Boxed_Number::equals), "==");
+        m.add(fun(&Boxed_Number::less_than), "<");
+        m.add(fun(&Boxed_Number::greater_than), ">");
+        m.add(fun(&Boxed_Number::greater_than_equal), ">=");
+        m.add(fun(&Boxed_Number::less_than_equal), "<=");
+        m.add(fun(&Boxed_Number::not_equal), "!=");
 
-        m->add(fun(&Boxed_Number::pre_decrement), "--");
-        m->add(fun(&Boxed_Number::pre_increment), "++");
-        m->add(fun(&Boxed_Number::sum), "+");
-        m->add(fun(&Boxed_Number::unary_plus), "+");
-        m->add(fun(&Boxed_Number::unary_minus), "-");
-        m->add(fun(&Boxed_Number::difference), "-");
-        m->add(fun(&Boxed_Number::assign_bitwise_and), "&=");
-        m->add(fun(&Boxed_Number::assign), "=");
-        m->add(fun(&Boxed_Number::assign_bitwise_or), "|=");
-        m->add(fun(&Boxed_Number::assign_bitwise_xor), "^=");
-        m->add(fun(&Boxed_Number::assign_remainder), "%=");
-        m->add(fun(&Boxed_Number::assign_shift_left), "<<=");
-        m->add(fun(&Boxed_Number::assign_shift_right), ">>=");
-        m->add(fun(&Boxed_Number::bitwise_and), "&");
-        m->add(fun(&Boxed_Number::bitwise_complement), "~");
-        m->add(fun(&Boxed_Number::bitwise_xor), "^");
-        m->add(fun(&Boxed_Number::bitwise_or), "|");
-        m->add(fun(&Boxed_Number::assign_product), "*=");
-        m->add(fun(&Boxed_Number::assign_quotient), "/=");
-        m->add(fun(&Boxed_Number::assign_sum), "+=");
-        m->add(fun(&Boxed_Number::assign_difference), "-=");
-        m->add(fun(&Boxed_Number::quotient), "/");
-        m->add(fun(&Boxed_Number::shift_left), "<<");
-        m->add(fun(&Boxed_Number::product), "*");
-        m->add(fun(&Boxed_Number::remainder), "%");
-        m->add(fun(&Boxed_Number::shift_right), ">>");
+        m.add(fun(&Boxed_Number::pre_decrement), "--");
+        m.add(fun(&Boxed_Number::pre_increment), "++");
+        m.add(fun(&Boxed_Number::sum), "+");
+        m.add(fun(&Boxed_Number::unary_plus), "+");
+        m.add(fun(&Boxed_Number::unary_minus), "-");
+        m.add(fun(&Boxed_Number::difference), "-");
+        m.add(fun(&Boxed_Number::assign_bitwise_and), "&=");
+        m.add(fun(&Boxed_Number::assign), "=");
+        m.add(fun(&Boxed_Number::assign_bitwise_or), "|=");
+        m.add(fun(&Boxed_Number::assign_bitwise_xor), "^=");
+        m.add(fun(&Boxed_Number::assign_remainder), "%=");
+        m.add(fun(&Boxed_Number::assign_shift_left), "<<=");
+        m.add(fun(&Boxed_Number::assign_shift_right), ">>=");
+        m.add(fun(&Boxed_Number::bitwise_and), "&");
+        m.add(fun(&Boxed_Number::bitwise_complement), "~");
+        m.add(fun(&Boxed_Number::bitwise_xor), "^");
+        m.add(fun(&Boxed_Number::bitwise_or), "|");
+        m.add(fun(&Boxed_Number::assign_product), "*=");
+        m.add(fun(&Boxed_Number::assign_quotient), "/=");
+        m.add(fun(&Boxed_Number::assign_sum), "+=");
+        m.add(fun(&Boxed_Number::assign_difference), "-=");
+        m.add(fun(&Boxed_Number::quotient), "/");
+        m.add(fun(&Boxed_Number::shift_left), "<<");
+        m.add(fun(&Boxed_Number::product), "*");
+        m.add(fun(&Boxed_Number::remainder), "%");
+        m.add(fun(&Boxed_Number::shift_right), ">>");
 
 
      }
@@ -403,57 +401,57 @@ namespace chaiscript
     public:
       /// \brief perform all common bootstrap functions for std::string, void and POD types
       /// \param[in,out] m Module to add bootstrapped functions to
-      /// \returns passed in ModulePtr, or newly created one if default argument is used
-      static ModulePtr bootstrap(ModulePtr m = std::make_shared<Module>())
+      /// \returns passed in Module
+      static Module& bootstrap(Module& m)
       {
-        m->add(user_type<void>(), "void");
-        m->add(user_type<bool>(), "bool");
-        m->add(user_type<Boxed_Value>(), "Object");
-        m->add(user_type<Boxed_Number>(), "Number");
-        m->add(user_type<Proxy_Function>(), "Function");
-        m->add(user_type<dispatch::Assignable_Proxy_Function>(), "Assignable_Function");
-        m->add(user_type<std::exception>(), "exception");
+        m.add(user_type<void>(), "void");
+        m.add(user_type<bool>(), "bool");
+        m.add(user_type<Boxed_Value>(), "Object");
+        m.add(user_type<Boxed_Number>(), "Number");
+        m.add(user_type<Proxy_Function>(), "Function");
+        m.add(user_type<dispatch::Assignable_Proxy_Function>(), "Assignable_Function");
+        m.add(user_type<std::exception>(), "exception");
 
-        m->add(fun(&dispatch::Proxy_Function_Base::get_arity), "get_arity");
-        m->add(fun(&dispatch::Proxy_Function_Base::annotation), "get_annotation");
-        m->add(fun(&dispatch::Proxy_Function_Base::operator==), "==");
-
-
-        m->add(fun(return_boxed_value_vector(&dispatch::Proxy_Function_Base::get_param_types)), "get_param_types");
-        m->add(fun(return_boxed_value_vector(&dispatch::Proxy_Function_Base::get_contained_functions)), "get_contained_functions");
+        m.add(fun(&dispatch::Proxy_Function_Base::get_arity), "get_arity");
+        m.add(fun(&dispatch::Proxy_Function_Base::annotation), "get_annotation");
+        m.add(fun(&dispatch::Proxy_Function_Base::operator==), "==");
 
 
-        m->add(user_type<std::out_of_range>(), "out_of_range");
-        m->add(user_type<std::logic_error>(), "logic_error");
-        m->add(chaiscript::base_class<std::exception, std::logic_error>());
-        m->add(chaiscript::base_class<std::logic_error, std::out_of_range>());
-        m->add(chaiscript::base_class<std::exception, std::out_of_range>());
+        m.add(fun(return_boxed_value_vector(&dispatch::Proxy_Function_Base::get_param_types)), "get_param_types");
+        m.add(fun(return_boxed_value_vector(&dispatch::Proxy_Function_Base::get_contained_functions)), "get_contained_functions");
 
-        m->add(user_type<std::runtime_error>(), "runtime_error");
-        m->add(chaiscript::base_class<std::exception, std::runtime_error>());
 
-        m->add(constructor<std::runtime_error (const std::string &)>(), "runtime_error");
-        m->add(fun(std::function<std::string (const std::runtime_error &)>(&what)), "what");
+        m.add(user_type<std::out_of_range>(), "out_of_range");
+        m.add(user_type<std::logic_error>(), "logic_error");
+        m.add(chaiscript::base_class<std::exception, std::logic_error>());
+        m.add(chaiscript::base_class<std::logic_error, std::out_of_range>());
+        m.add(chaiscript::base_class<std::exception, std::out_of_range>());
 
-        m->add(user_type<dispatch::Dynamic_Object>(), "Dynamic_Object");
-        m->add(constructor<dispatch::Dynamic_Object (const std::string &)>(), "Dynamic_Object");
-        m->add(constructor<dispatch::Dynamic_Object ()>(), "Dynamic_Object");
-        m->add(fun(&dispatch::Dynamic_Object::get_type_name), "get_type_name");
-        m->add(fun(&dispatch::Dynamic_Object::get_attrs), "get_attrs");
-        m->add(fun(&dispatch::Dynamic_Object::set_explicit), "set_explicit");
-        m->add(fun(&dispatch::Dynamic_Object::is_explicit), "is_explicit");
-        m->add(fun(&dispatch::Dynamic_Object::has_attr), "has_attr");
+        m.add(user_type<std::runtime_error>(), "runtime_error");
+        m.add(chaiscript::base_class<std::exception, std::runtime_error>());
 
-        m->add(fun(static_cast<Boxed_Value & (dispatch::Dynamic_Object::*)(const std::string &)>(&dispatch::Dynamic_Object::get_attr)), "get_attr");
-        m->add(fun(static_cast<const Boxed_Value & (dispatch::Dynamic_Object::*)(const std::string &) const>(&dispatch::Dynamic_Object::get_attr)), "get_attr");
+        m.add(constructor<std::runtime_error (const std::string &)>(), "runtime_error");
+        m.add(fun(std::function<std::string (const std::runtime_error &)>(&what)), "what");
 
-        m->add(fun(static_cast<Boxed_Value & (dispatch::Dynamic_Object::*)(const std::string &)>(&dispatch::Dynamic_Object::method_missing)), "method_missing");
-        m->add(fun(static_cast<const Boxed_Value & (dispatch::Dynamic_Object::*)(const std::string &) const>(&dispatch::Dynamic_Object::method_missing)), "method_missing");
+        m.add(user_type<dispatch::Dynamic_Object>(), "Dynamic_Object");
+        m.add(constructor<dispatch::Dynamic_Object (const std::string &)>(), "Dynamic_Object");
+        m.add(constructor<dispatch::Dynamic_Object ()>(), "Dynamic_Object");
+        m.add(fun(&dispatch::Dynamic_Object::get_type_name), "get_type_name");
+        m.add(fun(&dispatch::Dynamic_Object::get_attrs), "get_attrs");
+        m.add(fun(&dispatch::Dynamic_Object::set_explicit), "set_explicit");
+        m.add(fun(&dispatch::Dynamic_Object::is_explicit), "is_explicit");
+        m.add(fun(&dispatch::Dynamic_Object::has_attr), "has_attr");
 
-        m->add(fun(static_cast<Boxed_Value & (dispatch::Dynamic_Object::*)(const std::string &)>(&dispatch::Dynamic_Object::get_attr)), "[]");
-        m->add(fun(static_cast<const Boxed_Value & (dispatch::Dynamic_Object::*)(const std::string &) const>(&dispatch::Dynamic_Object::get_attr)), "[]");
+        m.add(fun(static_cast<Boxed_Value & (dispatch::Dynamic_Object::*)(const std::string &)>(&dispatch::Dynamic_Object::get_attr)), "get_attr");
+        m.add(fun(static_cast<const Boxed_Value & (dispatch::Dynamic_Object::*)(const std::string &) const>(&dispatch::Dynamic_Object::get_attr)), "get_attr");
 
-        m->eval(R"chaiscript(
+        m.add(fun(static_cast<Boxed_Value & (dispatch::Dynamic_Object::*)(const std::string &)>(&dispatch::Dynamic_Object::method_missing)), "method_missing");
+        m.add(fun(static_cast<const Boxed_Value & (dispatch::Dynamic_Object::*)(const std::string &) const>(&dispatch::Dynamic_Object::method_missing)), "method_missing");
+
+        m.add(fun(static_cast<Boxed_Value & (dispatch::Dynamic_Object::*)(const std::string &)>(&dispatch::Dynamic_Object::get_attr)), "[]");
+        m.add(fun(static_cast<const Boxed_Value & (dispatch::Dynamic_Object::*)(const std::string &) const>(&dispatch::Dynamic_Object::get_attr)), "[]");
+
+        m.eval(R"chaiscript(
           def Dynamic_Object::clone() { 
             auto &new_o = Dynamic_Object(this.get_type_name()); 
             for_each(this.get_attrs(), fun[new_o](x) { new_o.get_attr(x.first) = x.second; } ); 
@@ -490,37 +488,37 @@ namespace chaiscript
           }
         )chaiscript");
 
-        m->add(fun(&has_guard), "has_guard");
-        m->add(fun(&get_guard), "get_guard");
+        m.add(fun(&has_guard), "has_guard");
+        m.add(fun(&get_guard), "get_guard");
 
-        m->add(fun(&Boxed_Value::is_undef), "is_var_undef");
-        m->add(fun(&Boxed_Value::is_null), "is_var_null");
-        m->add(fun(&Boxed_Value::is_const), "is_var_const");
-        m->add(fun(&Boxed_Value::is_ref), "is_var_reference");
-        m->add(fun(&Boxed_Value::is_pointer), "is_var_pointer");
-        m->add(fun(&Boxed_Value::is_return_value), "is_var_return_value");
-        m->add(fun(&Boxed_Value::reset_return_value), "reset_var_return_value");
-        m->add(fun(&Boxed_Value::is_type), "is_type");
-        m->add(fun(&Boxed_Value::get_attr), "get_var_attr");
-        m->add(fun(&Boxed_Value::copy_attrs), "copy_var_attrs");
-        m->add(fun(&Boxed_Value::clone_attrs), "clone_var_attrs");
+        m.add(fun(&Boxed_Value::is_undef), "is_var_undef");
+        m.add(fun(&Boxed_Value::is_null), "is_var_null");
+        m.add(fun(&Boxed_Value::is_const), "is_var_const");
+        m.add(fun(&Boxed_Value::is_ref), "is_var_reference");
+        m.add(fun(&Boxed_Value::is_pointer), "is_var_pointer");
+        m.add(fun(&Boxed_Value::is_return_value), "is_var_return_value");
+        m.add(fun(&Boxed_Value::reset_return_value), "reset_var_return_value");
+        m.add(fun(&Boxed_Value::is_type), "is_type");
+        m.add(fun(&Boxed_Value::get_attr), "get_var_attr");
+        m.add(fun(&Boxed_Value::copy_attrs), "copy_var_attrs");
+        m.add(fun(&Boxed_Value::clone_attrs), "clone_var_attrs");
 
-        m->add(fun(&Boxed_Value::get_type_info), "get_type_info");
-        m->add(user_type<Type_Info>(), "Type_Info");
-        m->add(constructor<Type_Info (const Type_Info &)>(), "Type_Info");
+        m.add(fun(&Boxed_Value::get_type_info), "get_type_info");
+        m.add(user_type<Type_Info>(), "Type_Info");
+        m.add(constructor<Type_Info (const Type_Info &)>(), "Type_Info");
 
 
         operators::equal<Type_Info>(m);
 
-        m->add(fun(&Type_Info::is_const), "is_type_const");
-        m->add(fun(&Type_Info::is_reference), "is_type_reference");
-        m->add(fun(&Type_Info::is_void), "is_type_void");
-        m->add(fun(&Type_Info::is_undef), "is_type_undef");
-        m->add(fun(&Type_Info::is_pointer), "is_type_pointer");
-        m->add(fun(&Type_Info::is_arithmetic), "is_type_arithmetic");
-        m->add(fun(&Type_Info::name), "cpp_name");
-        m->add(fun(&Type_Info::bare_name), "cpp_bare_name");
-        m->add(fun(&Type_Info::bare_equal), "bare_equal");
+        m.add(fun(&Type_Info::is_const), "is_type_const");
+        m.add(fun(&Type_Info::is_reference), "is_type_reference");
+        m.add(fun(&Type_Info::is_void), "is_type_void");
+        m.add(fun(&Type_Info::is_undef), "is_type_undef");
+        m.add(fun(&Type_Info::is_pointer), "is_type_pointer");
+        m.add(fun(&Type_Info::is_arithmetic), "is_type_arithmetic");
+        m.add(fun(&Type_Info::name), "cpp_name");
+        m.add(fun(&Type_Info::bare_name), "cpp_bare_name");
+        m.add(fun(&Type_Info::bare_equal), "bare_equal");
 
 
         basic_constructors<bool>("bool", m);
@@ -528,14 +526,14 @@ namespace chaiscript
         operators::equal<bool>(m);
         operators::not_equal<bool>(m);
 
-        m->add(fun([](const std::string &s) -> std::string { return s; }), "to_string");
-        m->add(fun(&Bootstrap::bool_to_string), "to_string");
-        m->add(fun(&unknown_assign), "=");
-        m->add(fun(&throw_exception), "throw");
-        m->add(fun(&what), "what");
+        m.add(fun([](const std::string &s) -> std::string { return s; }), "to_string");
+        m.add(fun(&Bootstrap::bool_to_string), "to_string");
+        m.add(fun(&unknown_assign), "=");
+        m.add(fun(&throw_exception), "throw");
+        m.add(fun(&what), "what");
 
-        m->add(fun(&to_string<char>), "to_string");
-        m->add(fun(&Boxed_Number::to_string), "to_string");
+        m.add(fun(&to_string<char>), "to_string");
+        m.add(fun(&Boxed_Number::to_string), "to_string");
 
         bootstrap_pod_type<double>("double", m);
         bootstrap_pod_type<long double>("long_double", m);
@@ -565,38 +563,38 @@ namespace chaiscript
         opers_arithmetic_pod(m);
 
 
-        m->add(fun(&print), "print_string");
-        m->add(fun(&println), "println_string");
+        m.add(fun(&print), "print_string");
+        m.add(fun(&println), "println_string");
 
-        m->add(dispatch::make_dynamic_proxy_function(&bind_function), "bind");
+        m.add(dispatch::make_dynamic_proxy_function(&bind_function), "bind");
 
-        m->add(fun(&shared_ptr_unconst_clone<dispatch::Proxy_Function_Base>), "clone");
-        m->add(fun(&ptr_assign<std::remove_const<dispatch::Proxy_Function_Base>::type>), "=");
-        m->add(fun(&ptr_assign<std::add_const<dispatch::Proxy_Function_Base>::type>), "=");
-        m->add(chaiscript::base_class<dispatch::Proxy_Function_Base, dispatch::Assignable_Proxy_Function>());
-        m->add(fun(
+        m.add(fun(&shared_ptr_unconst_clone<dispatch::Proxy_Function_Base>), "clone");
+        m.add(fun(&ptr_assign<std::remove_const<dispatch::Proxy_Function_Base>::type>), "=");
+        m.add(fun(&ptr_assign<std::add_const<dispatch::Proxy_Function_Base>::type>), "=");
+        m.add(chaiscript::base_class<dispatch::Proxy_Function_Base, dispatch::Assignable_Proxy_Function>());
+        m.add(fun(
                   [](dispatch::Assignable_Proxy_Function &t_lhs, const std::shared_ptr<const dispatch::Proxy_Function_Base> &t_rhs) {
                     t_lhs.assign(t_rhs);
                   }
                 ), "="
               );
 
-        m->add(fun(&Boxed_Value::type_match), "type_match");
+        m.add(fun(&Boxed_Value::type_match), "type_match");
 
 
-        m->add(chaiscript::fun(&has_parse_tree), "has_parse_tree");
-        m->add(chaiscript::fun(&get_parse_tree), "get_parse_tree");
+        m.add(chaiscript::fun(&has_parse_tree), "has_parse_tree");
+        m.add(chaiscript::fun(&get_parse_tree), "get_parse_tree");
 
-        m->add(chaiscript::base_class<std::runtime_error, chaiscript::exception::eval_error>());
+        m.add(chaiscript::base_class<std::runtime_error, chaiscript::exception::eval_error>());
 
-        m->add(chaiscript::user_type<chaiscript::exception::arithmetic_error>(), "arithmetic_error");
-        m->add(chaiscript::base_class<std::runtime_error, chaiscript::exception::arithmetic_error>());
+        m.add(chaiscript::user_type<chaiscript::exception::arithmetic_error>(), "arithmetic_error");
+        m.add(chaiscript::base_class<std::runtime_error, chaiscript::exception::arithmetic_error>());
 
 
 //        chaiscript::bootstrap::standard_library::vector_type<std::vector<std::shared_ptr<chaiscript::AST_Node> > >("AST_NodeVector", m);
 
 
-        chaiscript::utility::add_class<chaiscript::exception::eval_error>(*m,
+        chaiscript::utility::add_class<chaiscript::exception::eval_error>(m,
             "eval_error",
             { },
             { {fun(&chaiscript::exception::eval_error::reason), "reason"},
@@ -611,7 +609,7 @@ namespace chaiscript
             );
 
 
-        chaiscript::utility::add_class<chaiscript::File_Position>(*m,
+        chaiscript::utility::add_class<chaiscript::File_Position>(m,
             "File_Position",
             { constructor<File_Position()>(),
               constructor<File_Position(int, int)>() },
@@ -620,7 +618,7 @@ namespace chaiscript
             );
 
 
-        chaiscript::utility::add_class<AST_Node>(*m, 
+        chaiscript::utility::add_class<AST_Node>(m,
             "AST_Node",
             {  },
             { {fun(&AST_Node::text), "text"},
@@ -641,7 +639,7 @@ namespace chaiscript
             );
 
 
-        chaiscript::utility::add_class<parser::ChaiScript_Parser>(*m,
+        chaiscript::utility::add_class<parser::ChaiScript_Parser>(m,
             "ChaiScript_Parser",
             { constructor<parser::ChaiScript_Parser ()>() },
             { {fun(&parser::ChaiScript_Parser::parse), "parse"},

--- a/include/chaiscript/dispatchkit/bootstrap_stl.hpp
+++ b/include/chaiscript/dispatchkit/bootstrap_stl.hpp
@@ -177,7 +177,7 @@ namespace chaiscript
 
         /// Add Bidir_Range support for the given ContainerType
         template<typename Bidir_Type>
-          Module& input_range_type_impl(const std::string &type, Module& m)
+          void input_range_type_impl(const std::string &type, Module& m)
           {
             m.add(user_type<Bidir_Type>(), type + "_Range");
 
@@ -190,9 +190,7 @@ namespace chaiscript
             m.add(fun(&Bidir_Type::front), "front");
             m.add(fun(&Bidir_Type::pop_back), "pop_back");
             m.add(fun(&Bidir_Type::back), "back");
-
-            return m;
-          } 
+          }
 
 
         /// Algorithm for inserting at a specific position into a container
@@ -230,11 +228,10 @@ namespace chaiscript
       }
 
       template<typename ContainerType>
-        Module& input_range_type(const std::string &type, Module& m)
+        void input_range_type(const std::string &type, Module& m)
         {
           detail::input_range_type_impl<Bidir_Range<ContainerType> >(type,m);
           detail::input_range_type_impl<Const_Bidir_Range<ContainerType> >("Const_" + type, m);
-          return m;
         }
       template<typename ContainerType>
         ModulePtr input_range_type(const std::string &type)
@@ -248,7 +245,7 @@ namespace chaiscript
       /// Add random_access_container concept to the given ContainerType
       /// http://www.sgi.com/tech/stl/RandomAccessContainer.html
       template<typename ContainerType>
-        Module& random_access_container_type(const std::string &/*type*/, Module& m)
+        void random_access_container_type(const std::string &/*type*/, Module& m)
         {
           //In the interest of runtime safety for the m, we prefer the at() method for [] access,
           //to throw an exception in an out of bounds condition.
@@ -267,8 +264,6 @@ namespace chaiscript
                   /// during dispatch. reevaluate
                   return c.at(static_cast<typename ContainerType::size_type>(index));
                 }), "[]");
-
-          return m;
         }
       template<typename ContainerType>
         ModulePtr random_access_container_type(const std::string &type)
@@ -283,11 +278,10 @@ namespace chaiscript
       /// Add assignable concept to the given ContainerType
       /// http://www.sgi.com/tech/stl/Assignable.html
       template<typename ContainerType>
-        Module& assignable_type(const std::string &type, Module& m)
+        void assignable_type(const std::string &type, Module& m)
         {
           copy_constructor<ContainerType>(type, m);
           operators::assign<ContainerType>(m);
-          return m;
         }
       template<typename ContainerType>
         ModulePtr assignable_type(const std::string &type)
@@ -301,12 +295,11 @@ namespace chaiscript
       /// Add container concept to the given ContainerType
       /// http://www.sgi.com/tech/stl/Container.html
       template<typename ContainerType>
-        Module& container_type(const std::string &/*type*/, Module& m)
+        void container_type(const std::string &/*type*/, Module& m)
         {
           m.add(fun([](const ContainerType *a) { return a->size(); } ), "size");
           m.add(fun([](const ContainerType *a) { return a->empty(); } ), "empty");
           m.add(fun([](ContainerType *a) { a->clear(); } ), "clear");
-          return m;
         }
       template <typename ContainerType>
         ModulePtr container_type(const std::string& type)
@@ -320,10 +313,9 @@ namespace chaiscript
       /// Add default constructable concept to the given Type
       /// http://www.sgi.com/tech/stl/DefaultConstructible.html
       template<typename Type>
-        Module& default_constructible_type(const std::string &type, Module& m)
+        void default_constructible_type(const std::string &type, Module& m)
         {
           m.add(constructor<Type ()>(), type);
-          return m;
         }
       template <typename Type>
         ModulePtr default_constructible_type(const std::string& type)
@@ -338,7 +330,7 @@ namespace chaiscript
       /// Add sequence concept to the given ContainerType
       /// http://www.sgi.com/tech/stl/Sequence.html
       template<typename ContainerType>
-        Module& sequence_type(const std::string &/*type*/, Module& m)
+        void sequence_type(const std::string &/*type*/, Module& m)
         {
           m.add(fun(&detail::insert_at<ContainerType>),
               []()->std::string{
@@ -350,8 +342,6 @@ namespace chaiscript
               }());
 
           m.add(fun(&detail::erase_at<ContainerType>), "erase_at");
-
-          return m;
         }
       template <typename ContainerType>
         ModulePtr sequence_type(const std::string &type)
@@ -364,7 +354,7 @@ namespace chaiscript
       /// Add back insertion sequence concept to the given ContainerType
       /// http://www.sgi.com/tech/stl/BackInsertionSequence.html
       template<typename ContainerType>
-        Module& back_insertion_sequence_type(const std::string &type, Module& m)
+        void back_insertion_sequence_type(const std::string &type, Module& m)
         {
           typedef typename ContainerType::reference (ContainerType::*backptr)();
 
@@ -395,7 +385,6 @@ namespace chaiscript
               }());
 
           m.add(fun(&ContainerType::pop_back), "pop_back");
-          return m;
         }
       template<typename ContainerType>
         ModulePtr back_insertion_sequence_type(const std::string &type)
@@ -410,7 +399,7 @@ namespace chaiscript
       /// Front insertion sequence
       /// http://www.sgi.com/tech/stl/FrontInsertionSequence.html
       template<typename ContainerType>
-        Module& front_insertion_sequence_type(const std::string &type, Module& m)
+        void front_insertion_sequence_type(const std::string &type, Module& m)
         {
           typedef typename ContainerType::reference (ContainerType::*front_ptr)();
           typedef typename ContainerType::const_reference (ContainerType::*const_front_ptr)() const;
@@ -442,7 +431,6 @@ namespace chaiscript
               }());
 
           m.add(fun(static_cast<pop_ptr>(&ContainerType::pop_front)), "pop_front");
-          return m;
         }
       template<typename ContainerType>
         ModulePtr front_insertion_sequence_type(const std::string &type)
@@ -456,7 +444,7 @@ namespace chaiscript
       /// bootstrap a given PairType
       /// http://www.sgi.com/tech/stl/pair.html
       template<typename PairType>
-        Module& pair_type(const std::string &type, Module& m)
+        void pair_type(const std::string &type, Module& m)
         {
           m.add(user_type<PairType>(), type);
 
@@ -469,8 +457,6 @@ namespace chaiscript
 
           basic_constructors<PairType>(type, m);
           m.add(constructor<PairType (const typename PairType::first_type &, const typename PairType::second_type &)>(), type);
-
-          return m;
         }
       template<typename PairType>
         ModulePtr pair_type(const std::string &type)
@@ -486,11 +472,9 @@ namespace chaiscript
       /// http://www.sgi.com/tech/stl/PairAssociativeContainer.html
 
       template<typename ContainerType>
-        Module& pair_associative_container_type(const std::string &type, Module& m)
+        void pair_associative_container_type(const std::string &type, Module& m)
         {
           pair_type<typename ContainerType::value_type>(type + "_Pair", m);
-
-          return m;
         }
       template<typename ContainerType>
         ModulePtr pair_associative_container_type(const std::string &type)
@@ -504,7 +488,7 @@ namespace chaiscript
       /// Add unique associative container concept to the given ContainerType
       /// http://www.sgi.com/tech/stl/UniqueAssociativeContainer.html
       template<typename ContainerType>
-        Module& unique_associative_container_type(const std::string &/*type*/, Module& m)
+        void unique_associative_container_type(const std::string &/*type*/, Module& m)
         {
           m.add(fun(detail::count<ContainerType>), "count");
 
@@ -522,9 +506,6 @@ namespace chaiscript
                   return "insert";
                 }
               }());
-
-
-          return m;
         }
       template<typename ContainerType>
         ModulePtr unique_associative_container_type(const std::string &type)
@@ -538,7 +519,7 @@ namespace chaiscript
       /// Add a MapType container
       /// http://www.sgi.com/tech/stl/Map.html
       template<typename MapType>
-        Module& map_type(const std::string &type, Module& m)
+        void map_type(const std::string &type, Module& m)
         {
           m.add(user_type<MapType>(), type);
 
@@ -580,8 +561,6 @@ namespace chaiscript
           unique_associative_container_type<MapType>(type, m);
           pair_associative_container_type<MapType>(type, m);
           input_range_type<MapType>(type, m);
-
-          return m;
         }
       template<typename MapType>
         ModulePtr map_type(const std::string &type)
@@ -595,7 +574,7 @@ namespace chaiscript
       /// hopefully working List type
       /// http://www.sgi.com/tech/stl/List.html
       template<typename ListType>
-        Module& list_type(const std::string &type, Module& m)
+        void list_type(const std::string &type, Module& m)
         {
           m.add(user_type<ListType>(), type);
 
@@ -606,8 +585,6 @@ namespace chaiscript
           default_constructible_type<ListType>(type, m);
           assignable_type<ListType>(type, m);
           input_range_type<ListType>(type, m);
-
-          return m;
         }
       template<typename ListType>
         ModulePtr list_type(const std::string &type)
@@ -621,7 +598,7 @@ namespace chaiscript
       /// Create a vector type with associated concepts
       /// http://www.sgi.com/tech/stl/Vector.html
       template<typename VectorType>
-        Module& vector_type(const std::string &type, Module& m)
+        void vector_type(const std::string &type, Module& m)
         {
           m.add(user_type<VectorType>(), type);
 
@@ -663,8 +640,6 @@ namespace chaiscript
                    } )"
                  );
           } 
-
-          return m;
         }
       template<typename VectorType>
         ModulePtr vector_type(const std::string &type)
@@ -677,7 +652,7 @@ namespace chaiscript
       /// Add a String container
       /// http://www.sgi.com/tech/stl/basic_string.html
       template<typename String>
-        Module& string_type(const std::string &type, Module& m)
+        void string_type(const std::string &type, Module& m)
         {
           m.add(user_type<String>(), type);
           operators::addition<String>(m);
@@ -715,8 +690,6 @@ namespace chaiscript
           m.add(fun([](const String *s) { return s->c_str(); } ), "c_str");
           m.add(fun([](const String *s) { return s->data(); } ), "data");
           m.add(fun([](const String *s, size_t pos, size_t len) { return s->substr(pos, len); } ), "substr");
-
-          return m;
         }
       template<typename String>
         ModulePtr string_type(const std::string &type)
@@ -731,15 +704,13 @@ namespace chaiscript
       /// Add a MapType container
       /// http://www.sgi.com/tech/stl/Map.html
       template<typename FutureType>
-        Module& future_type(const std::string &type, Module& m)
+        void future_type(const std::string &type, Module& m)
         {
           m.add(user_type<FutureType>(), type);
 
           m.add(fun([](const FutureType &t) { return t.valid(); }), "valid");
           m.add(fun(&FutureType::get), "get");
           m.add(fun(&FutureType::wait), "wait");
-
-          return m;
         }
       template<typename FutureType>
         ModulePtr future_type(const std::string &type)

--- a/include/chaiscript/dispatchkit/bootstrap_stl.hpp
+++ b/include/chaiscript/dispatchkit/bootstrap_stl.hpp
@@ -236,6 +236,13 @@ namespace chaiscript
           detail::input_range_type_impl<Const_Bidir_Range<ContainerType> >("Const_" + type, m);
           return m;
         }
+      template<typename ContainerType>
+        ModulePtr input_range_type(const std::string &type)
+        {
+          auto m = std::make_shared<Module>();
+          input_range_type<ContainerType>(type, *m);
+          return m;
+        }
 
 
       /// Add random_access_container concept to the given ContainerType
@@ -263,6 +270,14 @@ namespace chaiscript
 
           return m;
         }
+      template<typename ContainerType>
+        ModulePtr random_access_container_type(const std::string &type)
+        {
+          auto m = std::make_shared<Module>();
+          random_access_container_type<ContainerType>(type, *m);
+          return m;
+        }
+
 
 
       /// Add assignable concept to the given ContainerType
@@ -272,6 +287,13 @@ namespace chaiscript
         {
           copy_constructor<ContainerType>(type, m);
           operators::assign<ContainerType>(m);
+          return m;
+        }
+      template<typename ContainerType>
+        ModulePtr assignable_type(const std::string &type)
+        {
+          auto m = std::make_shared<Module>();
+          assignable_type<ContainerType>(type, *m);
           return m;
         }
 
@@ -286,6 +308,13 @@ namespace chaiscript
           m.add(fun([](ContainerType *a) { a->clear(); } ), "clear");
           return m;
         }
+      template <typename ContainerType>
+        ModulePtr container_type(const std::string& type)
+      {
+        auto m = std::make_shared<Module>();
+        container_type<ContainerType>(type, *m);
+        return m;
+      }
 
 
       /// Add default constructable concept to the given Type
@@ -296,7 +325,13 @@ namespace chaiscript
           m.add(constructor<Type ()>(), type);
           return m;
         }
-
+      template <typename Type>
+        ModulePtr default_constructible_type(const std::string& type)
+        {
+          auto m = std::make_shared<Module>();
+          default_constructible_type<Type>(type, *m);
+          return m;
+        }
 
 
 
@@ -318,7 +353,13 @@ namespace chaiscript
 
           return m;
         }
-
+      template <typename ContainerType>
+        ModulePtr sequence_type(const std::string &type)
+        {
+          auto m = std::make_shared<Module>();
+          sequence_type<ContainerType>(type, *m);
+          return m;
+        }
 
       /// Add back insertion sequence concept to the given ContainerType
       /// http://www.sgi.com/tech/stl/BackInsertionSequence.html
@@ -354,6 +395,13 @@ namespace chaiscript
               }());
 
           m.add(fun(&ContainerType::pop_back), "pop_back");
+          return m;
+        }
+      template<typename ContainerType>
+        ModulePtr back_insertion_sequence_type(const std::string &type)
+        {
+          auto m = std::make_shared<Module>();
+          back_insertion_sequence_type<ContainerType>(type, *m);
           return m;
         }
 
@@ -396,6 +444,13 @@ namespace chaiscript
           m.add(fun(static_cast<pop_ptr>(&ContainerType::pop_front)), "pop_front");
           return m;
         }
+      template<typename ContainerType>
+        ModulePtr front_insertion_sequence_type(const std::string &type)
+        {
+          auto m = std::make_shared<Module>();
+          front_insertion_sequence_type<ContainerType>(type, *m);
+          return m;
+        }
 
 
       /// bootstrap a given PairType
@@ -417,6 +472,13 @@ namespace chaiscript
 
           return m;
         }
+      template<typename PairType>
+        ModulePtr pair_type(const std::string &type)
+        {
+          auto m = std::make_shared<Module>();
+          pair_type<PairType>(type, *m);
+          return m;
+        }
 
 
 
@@ -428,6 +490,13 @@ namespace chaiscript
         {
           pair_type<typename ContainerType::value_type>(type + "_Pair", m);
 
+          return m;
+        }
+      template<typename ContainerType>
+        ModulePtr pair_associative_container_type(const std::string &type)
+        {
+          auto m = std::make_shared<Module>();
+          pair_associative_container_type<ContainerType>(type, *m);
           return m;
         }
 
@@ -455,6 +524,13 @@ namespace chaiscript
               }());
 
 
+          return m;
+        }
+      template<typename ContainerType>
+        ModulePtr unique_associative_container_type(const std::string &type)
+        {
+          auto m = std::make_shared<Module>();
+          unique_associative_container_type<ContainerType>(type, *m);
           return m;
         }
 
@@ -507,6 +583,13 @@ namespace chaiscript
 
           return m;
         }
+      template<typename MapType>
+        ModulePtr map_type(const std::string &type)
+        {
+          auto m = std::make_shared<Module>();
+          map_type<MapType>(type, *m);
+          return m;
+        }
 
 
       /// hopefully working List type
@@ -524,6 +607,13 @@ namespace chaiscript
           assignable_type<ListType>(type, m);
           input_range_type<ListType>(type, m);
 
+          return m;
+        }
+      template<typename ListType>
+        ModulePtr list_type(const std::string &type)
+        {
+          auto m = std::make_shared<Module>();
+          list_type<ListType>(type, m);
           return m;
         }
 
@@ -576,6 +666,13 @@ namespace chaiscript
 
           return m;
         }
+      template<typename VectorType>
+        ModulePtr vector_type(const std::string &type)
+        {
+          auto m = std::make_shared<Module>();
+          vector_type<VectorType>(type, *m);
+          return m;
+        }
 
       /// Add a String container
       /// http://www.sgi.com/tech/stl/basic_string.html
@@ -621,6 +718,13 @@ namespace chaiscript
 
           return m;
         }
+      template<typename String>
+        ModulePtr string_type(const std::string &type)
+        {
+          auto m = std::make_shared<Module>();
+          string_type<String>(type, *m);
+          return m;
+        }
 
 
 
@@ -635,6 +739,13 @@ namespace chaiscript
           m.add(fun(&FutureType::get), "get");
           m.add(fun(&FutureType::wait), "wait");
 
+          return m;
+        }
+      template<typename FutureType>
+        ModulePtr future_type(const std::string &type)
+        {
+          auto m = std::make_shared<Module>();
+          future_type<FutureType>(type, *m);
           return m;
         }
     }

--- a/include/chaiscript/dispatchkit/dispatchkit.hpp
+++ b/include/chaiscript/dispatchkit/dispatchkit.hpp
@@ -178,12 +178,6 @@ namespace chaiscript
         return *this;
       }
 
-      Module &add(const std::shared_ptr<Module> &m)
-      {
-        m->apply(*this, *this);
-        return *m;
-      }
-
       template<typename Eval, typename Engine>
         void apply(Eval &t_eval, Engine &t_engine) const
         {

--- a/include/chaiscript/dispatchkit/operators.hpp
+++ b/include/chaiscript/dispatchkit/operators.hpp
@@ -229,234 +229,201 @@ namespace chaiscript
 
 
       template<typename T>
-        ModulePtr assign(ModulePtr m = std::make_shared<Module>())
+        Module& assign(Module& m)
         {
-          m->add(chaiscript::fun(&detail::assign<T &, const T&>), "=");
-          return m;
+          return m.add(chaiscript::fun(&detail::assign<T &, const T&>), "=");
         }
 
       template<typename T>
-        ModulePtr assign_bitwise_and(ModulePtr m = std::make_shared<Module>())
+        Module& assign_bitwise_and(Module& m)
         {
-          m->add(chaiscript::fun(&detail::assign_bitwise_and<T &, const T&>), "&=");
-          return m;
+          return m.add(chaiscript::fun(&detail::assign_bitwise_and<T &, const T&>), "&=");
         }
 
       template<typename T>
-        ModulePtr assign_xor(ModulePtr m = std::make_shared<Module>())
+        Module& assign_xor(Module& m)
         {
-          m->add(chaiscript::fun(&detail::assign_xor<T &, const T&>), "^=");
-          return m;
+          return m.add(chaiscript::fun(&detail::assign_xor<T &, const T&>), "^=");
         }
 
       template<typename T>
-        ModulePtr assign_bitwise_or(ModulePtr m = std::make_shared<Module>())
+        Module& assign_bitwise_or(Module& m)
         {
-          m->add(chaiscript::fun(&detail::assign_bitwise_or<T &, const T&>), "|=");
-          return m;
+          return m.add(chaiscript::fun(&detail::assign_bitwise_or<T &, const T&>), "|=");
         }
 
       template<typename T>
-        ModulePtr assign_difference(ModulePtr m = std::make_shared<Module>())
+        Module& assign_difference(Module& m)
         {
-          m->add(chaiscript::fun(&detail::assign_difference<T &, const T&>), "-=");
-          return m;
+          return m.add(chaiscript::fun(&detail::assign_difference<T &, const T&>), "-=");
         }
 
       template<typename T>
-        ModulePtr assign_left_shift(ModulePtr m = std::make_shared<Module>())
+        Module& assign_left_shift(Module& m)
         {
-          m->add(chaiscript::fun(&detail::assign_left_shift<T &, const T&>), "<<=");
-          return m;
+          return m.add(chaiscript::fun(&detail::assign_left_shift<T &, const T&>), "<<=");
         }
 
       template<typename T>
-        ModulePtr assign_product(ModulePtr m = std::make_shared<Module>())
+        Module& assign_product(Module& m)
         {
-          m->add(chaiscript::fun(&detail::assign_product<T &, const T&>), "*=");
-          return m;
+          return m.add(chaiscript::fun(&detail::assign_product<T &, const T&>), "*=");
         }
 
       template<typename T>
-        ModulePtr assign_quotient(ModulePtr m = std::make_shared<Module>())
+        Module& assign_quotient(Module& m)
         {
-          m->add(chaiscript::fun(&detail::assign_quotient<T &, const T&>), "/=");
-          return m;
+          return m.add(chaiscript::fun(&detail::assign_quotient<T &, const T&>), "/=");
         }
 
       template<typename T>
-        ModulePtr assign_remainder(ModulePtr m = std::make_shared<Module>())
+        Module& assign_remainder(Module& m)
         {
-          m->add(chaiscript::fun(&detail::assign_remainder<T &, const T&>), "%=");
-          return m;
+          return m.add(chaiscript::fun(&detail::assign_remainder<T &, const T&>), "%=");
         }
 
       template<typename T>
-        ModulePtr assign_right_shift(ModulePtr m = std::make_shared<Module>())
+        Module& assign_right_shift(Module& m)
         {
-          m->add(chaiscript::fun(&detail::assign_right_shift<T &, const T&>), ">>=");
-          return m;
+          return m.add(chaiscript::fun(&detail::assign_right_shift<T &, const T&>), ">>=");
         }
 
       template<typename T>
-        ModulePtr assign_sum(ModulePtr m = std::make_shared<Module>())
+        Module& assign_sum(Module& m)
         {
-          m->add(chaiscript::fun(&detail::assign_sum<T &, const T&>), "+=");
-          return m;
+          return m.add(chaiscript::fun(&detail::assign_sum<T &, const T&>), "+=");
         }
 
       template<typename T>
-        ModulePtr prefix_decrement(ModulePtr m = std::make_shared<Module>())
+        Module& prefix_decrement(Module& m)
         {
-          m->add(chaiscript::fun(&detail::prefix_decrement<T &>), "--");
-          return m;
+          return m.add(chaiscript::fun(&detail::prefix_decrement<T &>), "--");
         }
 
       template<typename T>
-        ModulePtr prefix_increment(ModulePtr m = std::make_shared<Module>())
+        Module& prefix_increment(Module& m)
         {
-          m->add(chaiscript::fun(&detail::prefix_increment<T &>), "++");
-          return m;
+          return m.add(chaiscript::fun(&detail::prefix_increment<T &>), "++");
         }
 
       template<typename T>
-        ModulePtr equal(ModulePtr m = std::make_shared<Module>())
+        Module& equal(Module& m)
         {
-          m->add(chaiscript::fun(&detail::equal<const T&, const T&>), "==");
-          return m;
+          return m.add(chaiscript::fun(&detail::equal<const T&, const T&>), "==");
         }
 
       template<typename T>
-        ModulePtr greater_than(ModulePtr m = std::make_shared<Module>())
+        Module& greater_than(Module& m)
         {
-          m->add(chaiscript::fun(&detail::greater_than<const T&, const T&>), ">");
-          return m;
+          return m.add(chaiscript::fun(&detail::greater_than<const T&, const T&>), ">");
         }
 
       template<typename T>
-        ModulePtr greater_than_equal(ModulePtr m = std::make_shared<Module>())
+        Module& greater_than_equal(Module& m)
         {
-          m->add(chaiscript::fun(&detail::greater_than_equal<const T&, const T&>), ">=");
-          return m;
+          return m.add(chaiscript::fun(&detail::greater_than_equal<const T&, const T&>), ">=");
         }
 
       template<typename T>
-        ModulePtr less_than(ModulePtr m = std::make_shared<Module>())
+        Module& less_than(Module& m)
         {
-          m->add(chaiscript::fun(&detail::less_than<const T&, const T&>), "<");
-          return m;
+          return m.add(chaiscript::fun(&detail::less_than<const T&, const T&>), "<");
         }
 
       template<typename T>
-        ModulePtr less_than_equal(ModulePtr m = std::make_shared<Module>())
+        Module& less_than_equal(Module& m)
         {
-          m->add(chaiscript::fun(&detail::less_than_equal<const T&, const T&>), "<=");
-          return m;
+          return m.add(chaiscript::fun(&detail::less_than_equal<const T&, const T&>), "<=");
         }
 
       template<typename T>
-        ModulePtr logical_compliment(ModulePtr m = std::make_shared<Module>())
+        Module& logical_compliment(Module& m)
         {
-          m->add(chaiscript::fun(&detail::logical_compliment<const T &>), "!");
-          return m;
+          return m.add(chaiscript::fun(&detail::logical_compliment<const T &>), "!");
         }
 
       template<typename T>
-        ModulePtr not_equal(ModulePtr m = std::make_shared<Module>())
+        Module& not_equal(Module& m)
         {
-          m->add(chaiscript::fun(&detail::not_equal<const T &, const T &>), "!=");
-          return m;
+          return m.add(chaiscript::fun(&detail::not_equal<const T &, const T &>), "!=");
         }
 
       template<typename T>
-        ModulePtr addition(ModulePtr m = std::make_shared<Module>())
+        Module& addition(Module& m)
         {
-          m->add(chaiscript::fun(&detail::addition<const T &, const T &>), "+");
-          return m;
+          return m.add(chaiscript::fun(&detail::addition<const T &, const T &>), "+");
         }
 
       template<typename T>
-        ModulePtr unary_plus(ModulePtr m = std::make_shared<Module>())
+        Module& unary_plus(Module& m)
         {
-          m->add(chaiscript::fun(&detail::unary_plus<const T &>), "+");
-          return m;
+          return m.add(chaiscript::fun(&detail::unary_plus<const T &>), "+");
         }
 
       template<typename T>
-        ModulePtr subtraction(ModulePtr m = std::make_shared<Module>())
+        Module& subtraction(Module& m)
         {
-          m->add(chaiscript::fun(&detail::subtraction<const T &, const T &>), "-");
-          return m;
+          return m.add(chaiscript::fun(&detail::subtraction<const T &, const T &>), "-");
         }
 
       template<typename T>
-        ModulePtr unary_minus(ModulePtr m = std::make_shared<Module>())
+        Module& unary_minus(Module& m)
         {
-          m->add(chaiscript::fun(&detail::unary_minus<const T &>), "-");
-          return m;
+          return m.add(chaiscript::fun(&detail::unary_minus<const T &>), "-");
         }
 
       template<typename T>
-        ModulePtr bitwise_and(ModulePtr m = std::make_shared<Module>())
+        Module& bitwise_and(Module& m)
         {
-          m->add(chaiscript::fun(&detail::bitwise_and<const T &, const T &>), "&");
-          return m;
+          return m.add(chaiscript::fun(&detail::bitwise_and<const T &, const T &>), "&");
         }
 
       template<typename T>
-        ModulePtr bitwise_compliment(ModulePtr m = std::make_shared<Module>())
+        Module& bitwise_compliment(Module& m)
         {
-          m->add(chaiscript::fun(&detail::bitwise_compliment<const T &>), "~");
-          return m;
+          return m.add(chaiscript::fun(&detail::bitwise_compliment<const T &>), "~");
         }
 
       template<typename T>
-        ModulePtr bitwise_xor(ModulePtr m = std::make_shared<Module>())
+        Module& bitwise_xor(Module& m)
         {
-          m->add(chaiscript::fun(&detail::bitwise_xor<const T &, const T &>), "^");
-          return m;
+          return m.add(chaiscript::fun(&detail::bitwise_xor<const T &, const T &>), "^");
         }
 
       template<typename T>
-        ModulePtr bitwise_or(ModulePtr m = std::make_shared<Module>())
+        Module& bitwise_or(Module& m)
         {
-          m->add(chaiscript::fun(&detail::bitwise_or<const T &, const T &>), "|");
-          return m;
+          return m.add(chaiscript::fun(&detail::bitwise_or<const T &, const T &>), "|");
         }
 
       template<typename T>
-        ModulePtr division(ModulePtr m = std::make_shared<Module>())
+        Module& division(Module& m)
         {
-          m->add(chaiscript::fun(&detail::division<const T &, const T &>), "/");
-          return m;
+          return m.add(chaiscript::fun(&detail::division<const T &, const T &>), "/");
         }
 
       template<typename T>
-        ModulePtr left_shift(ModulePtr m = std::make_shared<Module>())
+        Module& left_shift(Module& m)
         {
-          m->add(chaiscript::fun(&detail::left_shift<const T &, const T &>), "<<");
-          return m;
+          return m.add(chaiscript::fun(&detail::left_shift<const T &, const T &>), "<<");
         }
 
       template<typename T>
-        ModulePtr multiplication(ModulePtr m = std::make_shared<Module>())
+        Module& multiplication(Module& m)
         {
-          m->add(chaiscript::fun(&detail::multiplication<const T &, const T &>), "*");
-          return m;
+          return m.add(chaiscript::fun(&detail::multiplication<const T &, const T &>), "*");
         }
 
       template<typename T>
-        ModulePtr remainder(ModulePtr m = std::make_shared<Module>())
+        Module& remainder(Module& m)
         {
-          m->add(chaiscript::fun(&detail::remainder<const T &, const T &>), "%");
-          return m;
+          return m.add(chaiscript::fun(&detail::remainder<const T &, const T &>), "%");
         }
 
       template<typename T>
-        ModulePtr right_shift(ModulePtr m = std::make_shared<Module>())
+        Module& right_shift(Module& m)
         {
-          m->add(chaiscript::fun(&detail::right_shift<const T &, const T &>), ">>");
-          return m;
+          return m.add(chaiscript::fun(&detail::right_shift<const T &, const T &>), ">>");
         }
     }
   }

--- a/include/chaiscript/dispatchkit/operators.hpp
+++ b/include/chaiscript/dispatchkit/operators.hpp
@@ -229,201 +229,201 @@ namespace chaiscript
 
 
       template<typename T>
-        Module& assign(Module& m)
+        void assign(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::assign<T &, const T&>), "=");
+          m.add(chaiscript::fun(&detail::assign<T &, const T&>), "=");
         }
 
       template<typename T>
-        Module& assign_bitwise_and(Module& m)
+        void assign_bitwise_and(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::assign_bitwise_and<T &, const T&>), "&=");
+          m.add(chaiscript::fun(&detail::assign_bitwise_and<T &, const T&>), "&=");
         }
 
       template<typename T>
-        Module& assign_xor(Module& m)
+        void assign_xor(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::assign_xor<T &, const T&>), "^=");
+          m.add(chaiscript::fun(&detail::assign_xor<T &, const T&>), "^=");
         }
 
       template<typename T>
-        Module& assign_bitwise_or(Module& m)
+        void assign_bitwise_or(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::assign_bitwise_or<T &, const T&>), "|=");
+          m.add(chaiscript::fun(&detail::assign_bitwise_or<T &, const T&>), "|=");
         }
 
       template<typename T>
-        Module& assign_difference(Module& m)
+        void assign_difference(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::assign_difference<T &, const T&>), "-=");
+          m.add(chaiscript::fun(&detail::assign_difference<T &, const T&>), "-=");
         }
 
       template<typename T>
-        Module& assign_left_shift(Module& m)
+        void assign_left_shift(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::assign_left_shift<T &, const T&>), "<<=");
+          m.add(chaiscript::fun(&detail::assign_left_shift<T &, const T&>), "<<=");
         }
 
       template<typename T>
-        Module& assign_product(Module& m)
+        void assign_product(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::assign_product<T &, const T&>), "*=");
+          m.add(chaiscript::fun(&detail::assign_product<T &, const T&>), "*=");
         }
 
       template<typename T>
-        Module& assign_quotient(Module& m)
+        void assign_quotient(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::assign_quotient<T &, const T&>), "/=");
+          m.add(chaiscript::fun(&detail::assign_quotient<T &, const T&>), "/=");
         }
 
       template<typename T>
-        Module& assign_remainder(Module& m)
+        void assign_remainder(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::assign_remainder<T &, const T&>), "%=");
+          m.add(chaiscript::fun(&detail::assign_remainder<T &, const T&>), "%=");
         }
 
       template<typename T>
-        Module& assign_right_shift(Module& m)
+        void assign_right_shift(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::assign_right_shift<T &, const T&>), ">>=");
+          m.add(chaiscript::fun(&detail::assign_right_shift<T &, const T&>), ">>=");
         }
 
       template<typename T>
-        Module& assign_sum(Module& m)
+        void assign_sum(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::assign_sum<T &, const T&>), "+=");
+          m.add(chaiscript::fun(&detail::assign_sum<T &, const T&>), "+=");
         }
 
       template<typename T>
-        Module& prefix_decrement(Module& m)
+        void prefix_decrement(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::prefix_decrement<T &>), "--");
+          m.add(chaiscript::fun(&detail::prefix_decrement<T &>), "--");
         }
 
       template<typename T>
-        Module& prefix_increment(Module& m)
+        void prefix_increment(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::prefix_increment<T &>), "++");
+          m.add(chaiscript::fun(&detail::prefix_increment<T &>), "++");
         }
 
       template<typename T>
-        Module& equal(Module& m)
+        void equal(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::equal<const T&, const T&>), "==");
+          m.add(chaiscript::fun(&detail::equal<const T&, const T&>), "==");
         }
 
       template<typename T>
-        Module& greater_than(Module& m)
+        void greater_than(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::greater_than<const T&, const T&>), ">");
+          m.add(chaiscript::fun(&detail::greater_than<const T&, const T&>), ">");
         }
 
       template<typename T>
-        Module& greater_than_equal(Module& m)
+        void greater_than_equal(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::greater_than_equal<const T&, const T&>), ">=");
+          m.add(chaiscript::fun(&detail::greater_than_equal<const T&, const T&>), ">=");
         }
 
       template<typename T>
-        Module& less_than(Module& m)
+        void less_than(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::less_than<const T&, const T&>), "<");
+          m.add(chaiscript::fun(&detail::less_than<const T&, const T&>), "<");
         }
 
       template<typename T>
-        Module& less_than_equal(Module& m)
+        void less_than_equal(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::less_than_equal<const T&, const T&>), "<=");
+          m.add(chaiscript::fun(&detail::less_than_equal<const T&, const T&>), "<=");
         }
 
       template<typename T>
-        Module& logical_compliment(Module& m)
+        void logical_compliment(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::logical_compliment<const T &>), "!");
+          m.add(chaiscript::fun(&detail::logical_compliment<const T &>), "!");
         }
 
       template<typename T>
-        Module& not_equal(Module& m)
+        void not_equal(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::not_equal<const T &, const T &>), "!=");
+          m.add(chaiscript::fun(&detail::not_equal<const T &, const T &>), "!=");
         }
 
       template<typename T>
-        Module& addition(Module& m)
+        void addition(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::addition<const T &, const T &>), "+");
+          m.add(chaiscript::fun(&detail::addition<const T &, const T &>), "+");
         }
 
       template<typename T>
-        Module& unary_plus(Module& m)
+        void unary_plus(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::unary_plus<const T &>), "+");
+          m.add(chaiscript::fun(&detail::unary_plus<const T &>), "+");
         }
 
       template<typename T>
-        Module& subtraction(Module& m)
+        void subtraction(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::subtraction<const T &, const T &>), "-");
+          m.add(chaiscript::fun(&detail::subtraction<const T &, const T &>), "-");
         }
 
       template<typename T>
-        Module& unary_minus(Module& m)
+        void unary_minus(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::unary_minus<const T &>), "-");
+          m.add(chaiscript::fun(&detail::unary_minus<const T &>), "-");
         }
 
       template<typename T>
-        Module& bitwise_and(Module& m)
+        void bitwise_and(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::bitwise_and<const T &, const T &>), "&");
+          m.add(chaiscript::fun(&detail::bitwise_and<const T &, const T &>), "&");
         }
 
       template<typename T>
-        Module& bitwise_compliment(Module& m)
+        void bitwise_compliment(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::bitwise_compliment<const T &>), "~");
+          m.add(chaiscript::fun(&detail::bitwise_compliment<const T &>), "~");
         }
 
       template<typename T>
-        Module& bitwise_xor(Module& m)
+        void bitwise_xor(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::bitwise_xor<const T &, const T &>), "^");
+          m.add(chaiscript::fun(&detail::bitwise_xor<const T &, const T &>), "^");
         }
 
       template<typename T>
-        Module& bitwise_or(Module& m)
+        void bitwise_or(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::bitwise_or<const T &, const T &>), "|");
+          m.add(chaiscript::fun(&detail::bitwise_or<const T &, const T &>), "|");
         }
 
       template<typename T>
-        Module& division(Module& m)
+        void division(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::division<const T &, const T &>), "/");
+          m.add(chaiscript::fun(&detail::division<const T &, const T &>), "/");
         }
 
       template<typename T>
-        Module& left_shift(Module& m)
+        void left_shift(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::left_shift<const T &, const T &>), "<<");
+          m.add(chaiscript::fun(&detail::left_shift<const T &, const T &>), "<<");
         }
 
       template<typename T>
-        Module& multiplication(Module& m)
+        void multiplication(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::multiplication<const T &, const T &>), "*");
+          m.add(chaiscript::fun(&detail::multiplication<const T &, const T &>), "*");
         }
 
       template<typename T>
-        Module& remainder(Module& m)
+        void remainder(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::remainder<const T &, const T &>), "%");
+          m.add(chaiscript::fun(&detail::remainder<const T &, const T &>), "%");
         }
 
       template<typename T>
-        Module& right_shift(Module& m)
+        void right_shift(Module& m)
         {
-          return m.add(chaiscript::fun(&detail::right_shift<const T &, const T &>), ">>");
+          m.add(chaiscript::fun(&detail::right_shift<const T &, const T &>), ">>");
         }
     }
   }

--- a/include/chaiscript/utility/json_wrap.hpp
+++ b/include/chaiscript/utility/json_wrap.hpp
@@ -9,11 +9,11 @@ namespace chaiscript
   {
     public:
 
-      static ModulePtr library(ModulePtr m = std::make_shared<Module>())
+      static Module& library(Module& m)
       {
 
-        m->add(chaiscript::fun([](const std::string &t_str) { return from_json(t_str); }), "from_json");
-        m->add(chaiscript::fun(&json_wrap::to_json), "to_json");
+        m.add(chaiscript::fun([](const std::string &t_str) { return from_json(t_str); }), "from_json");
+        m.add(chaiscript::fun(&json_wrap::to_json), "to_json");
 
         return m;
 

--- a/include/chaiscript/utility/utility.hpp
+++ b/include/chaiscript/utility/utility.hpp
@@ -78,7 +78,9 @@ namespace chaiscript
         t_module.add(chaiscript::constructor<Enum (const Enum &)>(), t_class_name);
 
         using namespace chaiscript::bootstrap::operators;
-        assign<Enum>(not_equal<Enum>(equal<Enum>(t_module)));
+        equal<Enum>(t_module);
+        not_equal<Enum>(t_module);
+        assign<Enum>(t_module);
 
         t_module.add(chaiscript::fun([](const Enum &e, const int &i) { return e == i; }), "==");
         t_module.add(chaiscript::fun([](const int &i, const Enum &e) { return i == e; }), "==");

--- a/include/chaiscript/utility/utility.hpp
+++ b/include/chaiscript/utility/utility.hpp
@@ -78,10 +78,7 @@ namespace chaiscript
         t_module.add(chaiscript::constructor<Enum (const Enum &)>(), t_class_name);
 
         using namespace chaiscript::bootstrap::operators;
-        t_module.add([](){
-              // add some comparison and assignment operators
-              return assign<Enum>(not_equal<Enum>(equal<Enum>()));
-            }());
+        assign<Enum>(not_equal<Enum>(equal<Enum>(t_module)));
 
         t_module.add(chaiscript::fun([](const Enum &e, const int &i) { return e == i; }), "==");
         t_module.add(chaiscript::fun([](const int &i, const Enum &e) { return i == e; }), "==");

--- a/src/stl_extra.cpp
+++ b/src/stl_extra.cpp
@@ -23,9 +23,9 @@
 
 CHAISCRIPT_MODULE_EXPORT chaiscript::ModulePtr create_chaiscript_module_stl_extra()
 {
-
-  auto module = chaiscript::bootstrap::standard_library::list_type<std::list<chaiscript::Boxed_Value> >("List");
-  module->add(chaiscript::bootstrap::standard_library::vector_type<std::vector<uint16_t> >("u16vector"));
+  auto module = std::make_shared<chaiscript::Module>();
+  chaiscript::bootstrap::standard_library::list_type<std::list<chaiscript::Boxed_Value> >("List", *module);
+  chaiscript::bootstrap::standard_library::vector_type<std::vector<uint16_t> >("u16vector", *module);
   module->add(chaiscript::vector_conversion<std::vector<uint16_t>>());
   return module;
 }

--- a/src/test_module.cpp
+++ b/src/test_module.cpp
@@ -189,9 +189,9 @@ CHAISCRIPT_MODULE_EXPORT  chaiscript::ModulePtr create_chaiscript_module_test_mo
   m->add(chaiscript::fun(&TestBaseType::set_string_val), "set_string_val");
 
   m->add(chaiscript::fun(&TestBaseType::mdarray), "mdarray");
-  m->add(chaiscript::bootstrap::array<int[2][3][5]>("IntArray_2_3_5"));
-  m->add(chaiscript::bootstrap::array<int[3][5]>("IntArray_3_5"));
-  m->add(chaiscript::bootstrap::array<int[5]>("IntArray_5"));
+  chaiscript::bootstrap::array<int[2][3][5]>("IntArray_2_3_5", *m);
+  chaiscript::bootstrap::array<int[3][5]>("IntArray_3_5", *m);
+  chaiscript::bootstrap::array<int[5]>("IntArray_5", *m);
 
   // member that is a function
   m->add(chaiscript::fun(&TestBaseType::func_member), "func_member");


### PR DESCRIPTION
This is one attempt to tackle build times of ChaiScript, and also the built size of the stdlib.

Passing `Module&` to/from the functions populating ChaiScript instead of `ModulePtr`, does reduce both build times and size of build binaries, although not at all substantially. The Modules are always owned by a `shared_ptr<>` in the context of use, so there is no risk that the reference becomes invalid.

The diff looks large, but it's pretty mechanical application of the same signature change over and over.