### PR TITLE
Expose std::vector and std::list resize, reserve and capacity methods

### DIFF
--- a/include/chaiscript/dispatchkit/bootstrap_stl.hpp
+++ b/include/chaiscript/dispatchkit/bootstrap_stl.hpp
@@ -315,6 +315,7 @@ namespace chaiscript
         void reservable_type(const std::string &/*type*/, Module& m)
         {
           m.add(fun([](ContainerType *a, typename ContainerType::size_type n) { return a->reserve(n); } ), "reserve");
+          m.add(fun([](const ContainerType *a) { return a->capacity(); } ), "capacity");
         }
       template<typename ContainerType>
         ModulePtr reservable_type(const std::string &type)

--- a/include/chaiscript/dispatchkit/bootstrap_stl.hpp
+++ b/include/chaiscript/dispatchkit/bootstrap_stl.hpp
@@ -292,6 +292,27 @@ namespace chaiscript
         }
 
 
+      /// Add container resize concept to the given ContainerType
+      /// http://www.cplusplus.com/reference/stl/
+      template<typename ContainerType>
+      ModulePtr resizable_type(const std::string &/*type*/, ModulePtr m = std::make_shared<Module>())
+      {
+          m->add(fun([](ContainerType *a, ContainerType::size_type n, ContainerType::value_type val) { return a->resize(n, val); } ), "resize");
+          m->add(fun([](ContainerType *a, ContainerType::size_type n) { return a->resize(n, ContainerType::value_type()); } ), "resize");
+          return m;
+      }
+
+
+      /// Add container reserve concept to the given ContainerType
+      /// http://www.cplusplus.com/reference/stl/
+      template<typename ContainerType>
+      ModulePtr reservable_type(const std::string &/*type*/, ModulePtr m = std::make_shared<Module>())
+      {
+          m->add(fun([](ContainerType *a, ContainerType::size_type n) { return a->reserve(n); } ), "reserve");
+          return m;
+      }
+
+
       /// Add container concept to the given ContainerType
       /// http://www.sgi.com/tech/stl/Container.html
       template<typename ContainerType>
@@ -581,6 +602,7 @@ namespace chaiscript
           front_insertion_sequence_type<ListType>(type, m);
           back_insertion_sequence_type<ListType>(type, m);
           sequence_type<ListType>(type, m);
+          resizable_type<ListType>(type, m);
           container_type<ListType>(type, m);
           default_constructible_type<ListType>(type, m);
           assignable_type<ListType>(type, m);
@@ -612,6 +634,8 @@ namespace chaiscript
           back_insertion_sequence_type<VectorType>(type, m);
           sequence_type<VectorType>(type, m);
           random_access_container_type<VectorType>(type, m);
+          resizable_type<VectorType>(type, m);
+          reservable_type<VectorType>(type, m);
           container_type<VectorType>(type, m);
           default_constructible_type<VectorType>(type, m);
           assignable_type<VectorType>(type, m);

--- a/include/chaiscript/dispatchkit/bootstrap_stl.hpp
+++ b/include/chaiscript/dispatchkit/bootstrap_stl.hpp
@@ -295,22 +295,34 @@ namespace chaiscript
       /// Add container resize concept to the given ContainerType
       /// http://www.cplusplus.com/reference/stl/
       template<typename ContainerType>
-      ModulePtr resizable_type(const std::string &/*type*/, ModulePtr m = std::make_shared<Module>())
-      {
-          m->add(fun([](ContainerType *a, ContainerType::size_type n, ContainerType::value_type val) { return a->resize(n, val); } ), "resize");
-          m->add(fun([](ContainerType *a, ContainerType::size_type n) { return a->resize(n, ContainerType::value_type()); } ), "resize");
+        void resizable_type(const std::string &/*type*/, Module& m)
+        {
+          m.add(fun([](ContainerType *a, ContainerType::size_type n, ContainerType::value_type val) { return a->resize(n, val); } ), "resize");
+          m.add(fun([](ContainerType *a, ContainerType::size_type n) { return a->resize(n, ContainerType::value_type()); } ), "resize");
+        }
+      template<typename ContainerType>
+        ModulePtr resizable_type(const std::string &type)
+        {
+          auto m = std::make_shared<Module>();
+          resizable_type<ContainerType>(type, *m);
           return m;
-      }
+        }
 
 
       /// Add container reserve concept to the given ContainerType
       /// http://www.cplusplus.com/reference/stl/
       template<typename ContainerType>
-      ModulePtr reservable_type(const std::string &/*type*/, ModulePtr m = std::make_shared<Module>())
-      {
-          m->add(fun([](ContainerType *a, ContainerType::size_type n) { return a->reserve(n); } ), "reserve");
+        void reservable_type(const std::string &/*type*/, Module& m)
+        {
+          m.add(fun([](ContainerType *a, ContainerType::size_type n) { return a->reserve(n); } ), "reserve");
+        }
+      template<typename ContainerType>
+        ModulePtr reservable_type(const std::string &type)
+        {
+          auto m = std::make_shared<Module>();
+          reservable_type<ContainerType>(type, *m);
           return m;
-      }
+        }
 
 
       /// Add container concept to the given ContainerType

--- a/include/chaiscript/dispatchkit/bootstrap_stl.hpp
+++ b/include/chaiscript/dispatchkit/bootstrap_stl.hpp
@@ -297,8 +297,8 @@ namespace chaiscript
       template<typename ContainerType>
         void resizable_type(const std::string &/*type*/, Module& m)
         {
-          m.add(fun([](ContainerType *a, ContainerType::size_type n, ContainerType::value_type val) { return a->resize(n, val); } ), "resize");
-          m.add(fun([](ContainerType *a, ContainerType::size_type n) { return a->resize(n, ContainerType::value_type()); } ), "resize");
+          m.add(fun([](ContainerType *a, typename ContainerType::size_type n, const typename ContainerType::value_type& val) { return a->resize(n, val); } ), "resize");
+          m.add(fun([](ContainerType *a, typename ContainerType::size_type n) { return a->resize(n); } ), "resize");
         }
       template<typename ContainerType>
         ModulePtr resizable_type(const std::string &type)
@@ -314,7 +314,7 @@ namespace chaiscript
       template<typename ContainerType>
         void reservable_type(const std::string &/*type*/, Module& m)
         {
-          m.add(fun([](ContainerType *a, ContainerType::size_type n) { return a->reserve(n); } ), "reserve");
+          m.add(fun([](ContainerType *a, typename ContainerType::size_type n) { return a->reserve(n); } ), "reserve");
         }
       template<typename ContainerType>
         ModulePtr reservable_type(const std::string &type)

--- a/unittests/list_resize.chai
+++ b/unittests/list_resize.chai
@@ -1,0 +1,13 @@
+load_module("stl_extra");
+
+auto list = List();
+
+list.resize(2);
+assert_equal(list.size(), 2);
+
+list.resize(6, "AAA");
+assert_equal(list[5], "AAA");
+
+list.resize(0);
+assert_equal(list.size(), 0);
+

--- a/unittests/list_resize.chai
+++ b/unittests/list_resize.chai
@@ -6,7 +6,7 @@ list.resize(2);
 assert_equal(list.size(), 2);
 
 list.resize(6, "AAA");
-assert_equal(list[5], "AAA");
+assert_equal(list.back(), "AAA");
 
 list.resize(0);
 assert_equal(list.size(), 0);

--- a/unittests/vector_reserve.chai
+++ b/unittests/vector_reserve.chai
@@ -3,5 +3,5 @@ load_module("stl_extra");
 auto uint16v = u16vector();
 
 uint16v.reserve(5);
-assert_true(uint16v.size() >= 5);
+assert_true(uint16v.capacity() >= 5);
 

--- a/unittests/vector_reserve.chai
+++ b/unittests/vector_reserve.chai
@@ -1,0 +1,7 @@
+load_module("stl_extra");
+
+auto uint16v = u16vector();
+
+uint16v.reserve(5);
+assert_true(uint16v.size() >= 5);
+

--- a/unittests/vector_resize.chai
+++ b/unittests/vector_resize.chai
@@ -1,0 +1,13 @@
+load_module("stl_extra");
+
+auto uint16v = u16vector();
+
+uint16v.resize(2);
+assert_equal(uint16v.size(), 2);
+
+uint16v.resize(6, 3);
+assert_equal(uint16v[5], 3);
+
+uint16v.resize(0);
+assert_equal(uint16v.size(), 0);
+


### PR DESCRIPTION
C++ **STL** containers **vector** and **list** can be resized from ChaiScript script
Additionally vector can reserve from script, can check current capacity

Adds to vector and list
- resize(size_type n, const value_type& val)
- resize(size_type n)

Adds to vector only
- reserve(size_type n)
- size_type capacity() const