### PR TITLE
Add UTF-8 escape notation to parser

### DIFF
--- a/include/chaiscript/chaiscript_defines.hpp
+++ b/include/chaiscript/chaiscript_defines.hpp
@@ -60,6 +60,10 @@
 #define CHAISCRIPT_MODULE_EXPORT extern "C" 
 #endif
 
+#if defined(CHAISCRIPT_MSVC) || (defined(__GNUC__) && __GNUC__ >= 5) || defined(CHAISCRIPT_CLANG)
+#define CHAISCRIPT_UTF16_UTF32
+#endif
+
 #ifdef _DEBUG
 #define CHAISCRIPT_DEBUG true
 #else

--- a/include/chaiscript/language/chaiscript_parser.hpp
+++ b/include/chaiscript/language/chaiscript_parser.hpp
@@ -58,26 +58,32 @@ namespace chaiscript
 
       // Generic for u16, u32 and (probably) wchar
       template<typename string_type>
-      string_type str_from_ll(long long val)
+      struct Char_Parser_Helper
       {
-        return string_type(1, string_type::value_type(val)); //size, character
-      }
+        static string_type str_from_ll(long long val)
+        {
+          return string_type(1, string_type::value_type(val)); //size, character
+        }
+      };
 
       // Specialization for char
       template<>
-      std::string str_from_ll<std::string>(long long val)
+      struct Char_Parser_Helper<std::string>
       {
-        std::string::value_type c[2];
-        c[1] = std::string::value_type(val);
-        c[0] = std::string::value_type(val >> 8);
-
-        if (c[0] == 0)
+        static std::string str_from_ll(long long val)
         {
-          return std::string(1, c[1]); //size, character
-        }
+          std::string::value_type c[2];
+          c[1] = std::string::value_type(val);
+          c[0] = std::string::value_type(val >> 8);
 
-        return std::string(c, 2); //char buffer, size
-      }
+          if (c[0] == 0)
+          {
+            return std::string(1, c[1]); //size, character
+          }
+
+          return std::string(c, 2); //char buffer, size
+        }
+      };
     }
 
     class ChaiScript_Parser {
@@ -1019,7 +1025,7 @@ namespace chaiscript
         {
           auto val = stoll(hex_matches, 0, 16);
           hex_matches.clear();
-          match += detail::str_from_ll<string_type>(val);
+          match += detail::Char_Parser_Helper<string_type>::str_from_ll(val);
           is_escaped = false;
           is_unicode = false;
         }

--- a/include/chaiscript/language/chaiscript_parser.hpp
+++ b/include/chaiscript/language/chaiscript_parser.hpp
@@ -55,6 +55,29 @@ namespace chaiscript
           ,   max_alphabet
           ,   lengthof_alphabet = 256
       };
+
+      // Generic for u16, u32 and (probably) wchar
+      template<typename string_type>
+      static string_type str_from_ll(long long val)
+      {
+        return string_type(1, string_type::value_type(val)); //size, character
+      }
+
+      // Specialization for char
+      template<>
+      static std::string str_from_ll<std::string>(long long val)
+      {
+        std::string::value_type c[2];
+        c[1] = std::string::value_type(val);
+        c[0] = std::string::value_type(val >> 8);
+
+        if (c[0] == 0)
+        {
+          return std::string(1, c[1]); //size, character
+        }
+
+        return std::string(c, 2); //char buffer, size
+      }
     }
 
     class ChaiScript_Parser {
@@ -928,29 +951,6 @@ namespace chaiscript
         return false;
       }
 
-      // Generic for u16, u32 and (probably) wchar
-      template<typename string_type>
-      static string_type str_from_ll(long long val)
-      {
-        return string_type(1, string_type::value_type(val)); //size, character
-      }
-
-      // Specialization for char
-      template<>
-      static std::string str_from_ll<std::string>(long long val)
-      {
-        std::string::value_type c[2];
-        c[1] = std::string::value_type(val);
-        c[0] = std::string::value_type(val >> 8);
-
-        if (c[0] == 0)
-        {
-          return std::string(1, c[1]); //size, character
-        }
-
-        return std::string(c, 2); //char buffer, size
-      }
-
       template<typename string_type>
       struct Char_Parser
       {
@@ -1019,7 +1019,7 @@ namespace chaiscript
         {
           auto val = stoll(hex_matches, 0, 16);
           hex_matches.clear();
-          match += str_from_ll<string_type>(val);
+          match += detail::str_from_ll<string_type>(val);
           is_escaped = false;
           is_unicode = false;
         }

--- a/include/chaiscript/language/chaiscript_parser.hpp
+++ b/include/chaiscript/language/chaiscript_parser.hpp
@@ -58,14 +58,14 @@ namespace chaiscript
 
       // Generic for u16, u32 and (probably) wchar
       template<typename string_type>
-      static string_type str_from_ll(long long val)
+      string_type str_from_ll(long long val)
       {
         return string_type(1, string_type::value_type(val)); //size, character
       }
 
       // Specialization for char
       template<>
-      static std::string str_from_ll<std::string>(long long val)
+      std::string str_from_ll<std::string>(long long val)
       {
         std::string::value_type c[2];
         c[1] = std::string::value_type(val);

--- a/include/chaiscript/language/chaiscript_parser.hpp
+++ b/include/chaiscript/language/chaiscript_parser.hpp
@@ -940,8 +940,8 @@ namespace chaiscript
       static std::string str_from_ll<std::string>(long long val)
       {
         std::string::value_type c[2];
-        c[1] = val;
-        c[0] = val >> 8;
+        c[1] = std::string::value_type(val);
+        c[0] = std::string::value_type(val >> 8);
 
         if (c[0] == 0)
         {

--- a/unittests/string_unicode_ascii.chai
+++ b/unittests/string_unicode_ascii.chai
@@ -1,0 +1,8 @@
+assert_equal('\u0020', ' ')
+assert_equal('\u0021', '!')
+assert_equal('\u0030', '0')
+assert_equal('\u0040', '@')
+assert_equal('\u005B', '[')
+assert_equal('\u005d', ']')
+assert_equal('\u0061', 'a')
+assert_equal('\u007e', '~')

--- a/unittests/string_unicode_parse.chai
+++ b/unittests/string_unicode_parse.chai
@@ -6,6 +6,6 @@ assert_equal('\udd', '\uDD')
 assert_equal('\u0ee', '\uEE')
 assert_equal('\ue', '\u000E')
 
-assert_equal("\u30\u31\u32", "123")
-assert_equal("\u33Test", "4Test")
+assert_equal("\u30\u31\u32", "012")
+assert_equal("\u33Test", "3Test")
 assert_equal("Test\u0040", "Test@")

--- a/unittests/string_unicode_parse.chai
+++ b/unittests/string_unicode_parse.chai
@@ -1,0 +1,11 @@
+assert_equal('\u00aa', '\u00AA')
+assert_equal('\u00bb', '\uBB')
+assert_equal('\ucc', '\u00CC')
+assert_equal('\udd', '\uDD')
+
+assert_equal('\u0ee', '\uEE')
+assert_equal('\ue', '\u000E')
+
+assert_equal("\u30\u31\u32", "123")
+assert_equal("\u33Test", "4Test")
+assert_equal("Test\u0040", "Test@")

--- a/unittests/string_unicode_unicode.chai
+++ b/unittests/string_unicode_unicode.chai
@@ -1,4 +1,4 @@
-assert_equal('\uc39c', 'Ü')
+assert_equal("\uc39c", "Ü")
 assert_equal("U for \uc39cmlauts", "U for Ümlauts")
 assert_equal("More \uc39cml\uc3a4\uc3bcts", "More Ümläüts")
 

--- a/unittests/string_unicode_unicode.chai
+++ b/unittests/string_unicode_unicode.chai
@@ -1,5 +1,5 @@
-assert_equal('\u0220', 'Ü')
-assert_equal("U for \u0220mlauts", "U for Ümlauts")
-assert_equal("More \u0220ml\u0228\u0252ts", "More Ümläüts")
+assert_equal('\uc39c', 'Ü')
+assert_equal("U for \uc39cmlauts", "U for Ümlauts")
+assert_equal("More \uc39cml\uc3a4\uc3bcts", "More Ümläüts")
 
-assert_equal("Happy \u30C4 face", "Happy ツ face")
+assert_equal("Thorn \uc3be sign", "Thorn þ sign")

--- a/unittests/string_unicode_unicode.chai
+++ b/unittests/string_unicode_unicode.chai
@@ -1,0 +1,5 @@
+assert_equal('\u0220', 'Ü')
+assert_equal("U for \u0220mlauts", "U for Ümlauts")
+assert_equal("More \u0220ml\u0228\u0252ts", "More Ümläüts")
+
+assert_equal("Happy \u30C4 face", "Happy ツ face")


### PR DESCRIPTION
Allow to use \uABCD - like notation inside values.
E.g. \u0020 codes for whitespace. Real life case - browser JSON parser/generator escapes square brackets, so [ and ] become \u005b and \u005d. Before these changes parsing strings from such browser caused exception because of unknown escape sequence, now values are properly translated during parsing.

Code supports MSVC 2013/2015, GCC > 5 and Clang. On other platforms, codecvt is not available, so fallback is used. This affect parser only if other type of string than std::string is used. For std::string, I think all platforms work where ChaiScript compiles.