### PR TITLE
nullify_shared_ptr changing == to = in documentation.

### DIFF
--- a/cheatsheet.md
+++ b/cheatsheet.md
@@ -206,7 +206,7 @@ Conversion to `std::shared_ptr<T> &` is supported for function calls, but if you
 ```cpp
 // ok this is supported, you can register it with chaiscript engine
 void nullify_shared_ptr(std::shared_ptr<int> &t) {
-  t == nullptr
+  t = nullptr
 }
 ```
 


### PR DESCRIPTION
Issue this pull request references: # no issue, just saw some incorrect documentation

Changes proposed in this pull request

 - Fix a one character issue with cheatsheet.md
 

