### PR TITLE
conan.io support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+conanbuildinfo.cmake
+*.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,17 @@ before_install:
   - export CXX="g++-$GCC_VER" CC="gcc-$GCC_VER" GCOV="gcov-$GCC_VER"
   - if [ "$GCC_VER" = "5" ]; then export COVERAGE=1 CPPCHECK=1; fi
   - if [ ${COVERAGE} = 1 ]; then export FUZZY_CMD="-D RUN_FUZZY_TESTS:BOOL=TRUE"; fi
-  - sudo pip install cpp-coveralls
+  - sudo pip install cpp-coveralls conan
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update
   - sudo apt-get install -qq g++-$GCC_VER
 
-script: 
+script:
   - if [ ${COVERITY_SCAN_BRANCH} != 1 ]; then cmake -D ENABLE_COVERAGE:BOOL=TRUE -D CMAKE_BUILD_TYPE:STRING=Debug $FUZZY_CMD . ; fi
   - if [ ${COVERITY_SCAN_BRANCH} != 1 ]; then make -j2 ; fi
   - make test
   - if [ ${COVERAGE} = 1 ]; then bash <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/master/codecov) -x $GCOV -a "-s `pwd`" ; fi
+  - conan test_package --build=outdated
 
 after_script:
   - if [ ${CPPCHECK} = 1 ]; then contrib/codeanalysis/runcppcheck.sh ; fi

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,36 @@
+from conans import ConanFile
+from conans.tools import download, untargz
+import os
+
+class Settings:
+    username = os.getenv('CONAN_CHAISCRIPT_USERNAME', 'Manu343726')
+    channel  = os.getenv('CONAN_CHAISCRIPT_CHANNEL', 'testing')
+    version  = os.getenv('CONAN_CHAISCRIPT_VERSION', '5.8.5')
+
+class ChaiScript(ConanFile):
+    settings = 'os'
+    name = 'ChaiScript'
+    url = 'http://chaiscript.com/'
+    license = 'BSD'
+    username = Settings.username
+    channel = Settings.channel
+    version = Settings.version
+    exports = '*.hpp', '*.chai'
+    generators = 'cmake'
+
+    def source(self):
+        name = '{}-{}'.format(self.name, self.version)
+        tar = name + '.tar.gz'
+        url = 'https://github.com/ChaiScript/ChaiScript/archive/v{}.tar.gz'.format(self.version)
+        download(url, tar)
+        untargz(tar)
+
+    def package(self):
+        includedir = os.path.join('include', 'chaiscript')
+        src_includedir = os.path.join('{}-{}'.format(self.name, self.version), includedir)
+        self.copy('*.hpp', src=src_includedir, dst=includedir)
+        self.copy('*.chai', src=src_includedir, dst=includedir)
+
+    def package_info(self):
+        if self.settings.os == 'Linux':
+            self.cpp_info.libs = ['dl', 'pthread']

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,8 @@ Develop Status: [![Linux Build Status](https://travis-ci.org/ChaiScript/ChaiScri
        src="https://img.shields.io/coverity/scan/5297.svg"/>
 </a>
 
+[![badge](https://img.shields.io/badge/conan.io-ChaiScript%2F5.8.5-green.svg?logo=data:image/png;base64%2CiVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAMAAAAolt3jAAAA1VBMVEUAAABhlctjlstkl8tlmMtlmMxlmcxmmcxnmsxpnMxpnM1qnc1sn85voM91oM11oc1xotB2oc56pNF6pNJ2ptJ8ptJ8ptN9ptN8p9N5qNJ9p9N9p9R8qtOBqdSAqtOAqtR%2BrNSCrNJ/rdWDrNWCsNWCsNaJs9eLs9iRvNuVvdyVv9yXwd2Zwt6axN6dxt%2Bfx%2BChyeGiyuGjyuCjyuGly%2BGlzOKmzOGozuKoz%2BKqz%2BOq0OOv1OWw1OWw1eWx1eWy1uay1%2Baz1%2Baz1%2Bez2Oe02Oe12ee22ujUGwH3AAAAAXRSTlMAQObYZgAAAAFiS0dEAIgFHUgAAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQfgBQkREyOxFIh/AAAAiklEQVQI12NgAAMbOwY4sLZ2NtQ1coVKWNvoc/Eq8XDr2wB5Ig62ekza9vaOqpK2TpoMzOxaFtwqZua2Bm4makIM7OzMAjoaCqYuxooSUqJALjs7o4yVpbowvzSUy87KqSwmxQfnsrPISyFzWeWAXCkpMaBVIC4bmCsOdgiUKwh3JojLgAQ4ZCE0AMm2D29tZwe6AAAAAElFTkSuQmCC)](http://www.conan.io/source/ChaiScript/5.8.5/Manu343726/testing)
+
 ChaiScript
 
 http://www.chaiscript.com

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,14 @@
+project(chaiscript_test_package)
+cmake_minimum_required(VERSION 2.8)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+include(${CONAN_CMAKE-UTILS_ROOT}/conan.cmake)
+conan_basic_setup()
+
+add_conan_library(chaiscript)
+
+add_executable(example example.cpp)
+if(NOT MSVC)
+    target_compile_options(example PRIVATE -std=c++14)
+endif()
+target_link_libraries(example PRIVATE chaiscript-conan)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conans import ConanFile, CMake
+from conans.tools import download, untargz
+import os
+
+class Settings:
+    username = os.getenv('CONAN_CHAISCRIPT_USERNAME', 'Manu343726')
+    channel  = os.getenv('CONAN_CHAISCRIPT_CHANNEL', 'testing')
+    version  = os.getenv('CONAN_CHAISCRIPT_VERSION', '5.8.5')
+
+class ChaiScriptTest(ConanFile):
+    settings = 'os', 'compiler', 'build_type', 'arch'
+    requires = (
+        'cmake-utils/0.0.0@Manu343726/testing',
+        'ChaiScript/{}@{}/{}'.format(Settings.version, Settings.username, Settings.channel)
+    )
+    generators = 'cmake'
+
+    def build(self):
+        cmake = CMake(self.settings)
+        self.run('cmake {} {}'.format(self.conanfile_directory, cmake.command_line))
+        self.run('cmake --build . {}'.format(cmake.build_config))
+
+    def test(self):
+        self.run(os.path.join('.', 'bin', 'example'))
+

--- a/test_package/example.cpp
+++ b/test_package/example.cpp
@@ -1,0 +1,15 @@
+#include <chaiscript/chaiscript.hpp>
+#include <chaiscript/chaiscript_stdlib.hpp>
+
+double function(int i, double j)
+{
+  return i * j;
+}
+
+int main()
+{
+  chaiscript::ChaiScript chai(chaiscript::Std_Lib::library());
+  chai.add(chaiscript::fun(&function), "function");
+
+  double d = chai.eval<double>("function(3, 4.75);");
+}


### PR DESCRIPTION
This commit adds an script to package ChaiScript as a conan.io package. It also adds a test to check the package usage. The package is written to work with releases, pointing to 5.8.5 by default.

The package is currently available under my account: https://www.conan.io/source/ChaiScript/5.8.5/Manu343726/testing
 
