### PR TITLE
Ability to disable module loading support at compile time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
       compiler: gcc
     - os: linux
       sudo: false
-      env: GCC_VER="5"
+      env: GCC_VER="5" CPPCHECK=1 COVERAGE=1 CMAKE_OPTIONS="-D RUN_FUZZY_TESTS:BOOL=TRUE"
       compiler: gcc
     - os: osx
       compiler: clang
@@ -47,7 +47,6 @@ env:
 
 before_install:
   - if [ "${GCC_VER}" != "" ]; then export CXX="g++-$GCC_VER" CC="gcc-$GCC_VER" GCOV="gcov-$GCC_VER" ; fi
-  - if [ "${GCC_VER}" == "5" &&  "${BUILD_ONLY}" != "1"]; then export CPPCHECK=1 COVERAGE=1 CMAKE_OPTIONS+=" -D RUN_FUZZY_TESTS:BOOL=TRUE" ; fi
   - pip install --user cpp-coveralls
 
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,19 @@ matrix:
       compiler: gcc
     - os: linux
       sudo: false
+      env: GCC_VER="4.9" CMAKE_OPTIONS="-D DYNLOAD_ENABLED:BOOL=FALSE -D MULTITHREAD_SUPPORT_ENABLED:BOOL=FALSE -D USE_STD_MAKE_SHARED:BOOL=TRUE" BUILD_ONLY=1
+      compiler: gcc
+    - os: linux
+      sudo: false
       env: GCC_VER="5"
       compiler: gcc
     - os: osx
       compiler: clang
       osx_image: xcode8
-
+    - os: osx
+      compiler: clang
+      osx_image: xcode8
+      env: CMAKE_OPTIONS="-D DYNLOAD_ENABLED:BOOL=FALSE -D MULTITHREAD_SUPPORT_ENABLED:BOOL=FALSE -D USE_STD_MAKE_SHARED:BOOL=TRUE" BUILD_ONLY=1
   
 env:
   global:
@@ -40,14 +47,14 @@ env:
 
 before_install:
   - if [ "${GCC_VER}" != "" ]; then export CXX="g++-$GCC_VER" CC="gcc-$GCC_VER" GCOV="gcov-$GCC_VER" ; fi
-  - if [ "${GCC_VER}" == "5" ]; then export CPPCHECK=1 COVERAGE=1 FUZZY_CMD="-D RUN_FUZZY_TESTS:BOOL=TRUE" ; fi
+  - if [ "${GCC_VER}" == "5" &&  "${BUILD_ONLY}" != "1"]; then export CPPCHECK=1 COVERAGE=1 CMAKE_OPTIONS+=" -D RUN_FUZZY_TESTS:BOOL=TRUE" ; fi
   - pip install --user cpp-coveralls
 
 script: 
-  - cmake -D ENABLE_COVERAGE:BOOL=TRUE -D CMAKE_BUILD_TYPE:STRING=Debug $FUZZY_CMD . 
+  - cmake -D ENABLE_COVERAGE:BOOL=TRUE -D CMAKE_BUILD_TYPE:STRING=Debug $CMAKE_OPTIONS . 
   - cmake --build . -- -j2
-  - ctest
-  - if [ ${COVERAGE} = 1 ]; then bash <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/master/codecov) -x $GCOV -a "-s `pwd`" ; fi
+  - if [ "${BUILD_ONLY}" != "1" ]; then ctest; fi
+  - if [ "${COVERAGE}" = "1" ]; then bash <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/master/codecov) -x $GCOV -a "-s `pwd`" ; fi
 
 #after_script:
 #  - if [ ${CPPCHECK} = 1 ]; then contrib/codeanalysis/runcppcheck.sh ; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ ELSE()
 project(chaiscript)
 
 option(MULTITHREAD_SUPPORT_ENABLED "Multithreaded Support Enabled" TRUE)
+option(DYNLOAD_ENABLED "Dynamic Loading Support Enabled" TRUE)
 
 
 option(BUILD_MODULES "Build Extra Modules (stl)" TRUE)
@@ -221,9 +222,15 @@ if(NOT MULTITHREAD_SUPPORT_ENABLED)
   add_definitions(-DCHAISCRIPT_NO_THREADS)
 endif()
 
+if(NOT DYNLOAD_ENABLED)
+  add_definitions(-DCHAISCRIPT_NO_DYNLOAD)
+endif()
+
 if(CMAKE_HOST_UNIX)
-  if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD" AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "Haiku")
-    list(APPEND LIBS "dl")
+  if(DYNLOAD_ENABLED)
+    if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD" AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "Haiku")
+      list(APPEND LIBS "dl")
+    endif()
   endif()
 
   if(MULTITHREAD_SUPPORT_ENABLED)

--- a/include/chaiscript/chaiscript_defines.hpp
+++ b/include/chaiscript/chaiscript_defines.hpp
@@ -216,7 +216,11 @@ namespace chaiscript {
 
   static inline std::vector<Options> default_options()
   {
+#ifdef CHAISCRIPT_NO_DYNLOAD
+    return {Options::No_Load_Modules, Options::External_Scripts};
+#else
     return {Options::Load_Modules, Options::External_Scripts};
+#endif
   }
 }
 #endif

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -243,7 +243,7 @@ namespace chaiscript
         m_parser(std::move(parser)),
         m_engine(*m_parser)
     {
-#if defined(_POSIX_VERSION) && !defined(__CYGWIN__) 
+#if !defined(CHAISCRIPT_NO_DYNLOAD) && defined(_POSIX_VERSION) && !defined(__CYGWIN__)
       // If on Unix, add the path of the current executable to the module search path
       // as windows would do
 

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -279,6 +279,7 @@ namespace chaiscript
       build_eval_system(t_lib, t_opts);
     }
 
+#ifndef CHAISCRIPT_NO_DYNLOAD
     /// \brief Constructor for ChaiScript.
     /// 
     /// This version of the ChaiScript constructor attempts to find the stdlib module to load
@@ -308,6 +309,12 @@ namespace chaiscript
         throw;
       }
     }
+#else // CHAISCRIPT_NO_DYNLOAD
+explicit ChaiScript_Basic(std::unique_ptr<parser::ChaiScript_Parser_Base> &&parser,
+                          std::vector<std::string> t_module_paths = {},
+                          std::vector<std::string> t_use_paths = {},
+                          const std::vector<chaiscript::Options> &t_opts = chaiscript::default_options()) = delete;
+#endif
 
     parser::ChaiScript_Parser_Base &get_parser()
     {

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -36,12 +36,13 @@
 #include <unistd.h>
 #endif
 
-#if defined(_POSIX_VERSION) && !defined(__CYGWIN__) 
+#if !defined(CHAISCRIPT_NO_DYNLOAD) && defined(_POSIX_VERSION) && !defined(__CYGWIN__)
 #include <dlfcn.h>
 #endif
 
-
-#ifdef CHAISCRIPT_WINDOWS
+#if defined(CHAISCRIPT_NO_DYNLOAD)
+#include "chaiscript_unknown.hpp"
+#elif defined(CHAISCRIPT_WINDOWS)
 #include "chaiscript_windows.hpp"
 #elif _POSIX_VERSION
 #include "chaiscript_posix.hpp"

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -556,6 +556,10 @@ explicit ChaiScript_Basic(std::unique_ptr<parser::ChaiScript_Parser_Base> &&pars
     /// \throw chaiscript::exception::load_module_error In the event that no matching module can be found.
     std::string load_module(const std::string &t_module_name)
     {
+#ifdef CHAISCRIPT_NO_DYNLOAD
+      (void)t_module_name; // -Wunused-parameter
+      throw chaiscript::exception::load_module_error("Loadable module support was disabled (CHAISCRIPT_NO_DYNLOAD)");
+#else
       std::vector<exception::load_module_error> errors;
       std::string version_stripped_name = t_module_name;
       size_t version_pos = version_stripped_name.find("-" + Build_Info::version());
@@ -589,6 +593,7 @@ explicit ChaiScript_Basic(std::unique_ptr<parser::ChaiScript_Parser_Base> &&pars
       }
 
       throw chaiscript::exception::load_module_error(t_module_name, errors);
+#endif
     }
 
     /// \brief Load a binary module from a dynamic library. Works on platforms that support

--- a/include/chaiscript/language/chaiscript_unknown.hpp
+++ b/include/chaiscript/language/chaiscript_unknown.hpp
@@ -16,7 +16,11 @@ namespace chaiscript
     {
       Loadable_Module(const std::string &, const std::string &)
       {
+#ifdef CHAISCRIPT_NO_DYNLOAD
+        throw chaiscript::exception::load_module_error("Loadable module support was disabled (CHAISCRIPT_NO_DYNLOAD)");
+#else
         throw chaiscript::exception::load_module_error("Loadable module support not available for your platform");
+#endif
       }
 
       ModulePtr m_moduleptr;

--- a/samples/fun_call_performance.cpp
+++ b/samples/fun_call_performance.cpp
@@ -68,6 +68,7 @@ std::vector<std::string> default_search_paths()
 {
   std::vector<std::string> paths;
 
+#ifndef CHAISCRIPT_NO_DYNLOAD
 #ifdef CHAISCRIPT_WINDOWS  // force no unicode
   CHAR path[4096];
   int size = GetModuleFileNameA(0, path, sizeof(path) - 1);
@@ -137,6 +138,7 @@ std::vector<std::string> default_search_paths()
     paths.push_back(exepath.substr(0, secondtolastslash) + "/lib/chaiscript/");
   }
 #endif
+#endif // ifndef CHAISCRIPT_NO_DYNLOAD
 
   return paths;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,6 +71,7 @@ std::vector<std::string> default_search_paths()
 {
   std::vector<std::string> paths;
 
+#ifndef CHAISCRIPT_NO_DYNLOAD
 #ifdef CHAISCRIPT_WINDOWS  // force no unicode
   CHAR path[4096];
   int size = GetModuleFileNameA(nullptr, path, sizeof(path)-1);
@@ -140,6 +141,7 @@ std::vector<std::string> default_search_paths()
     paths.push_back(exepath.substr(0, secondtolastslash) + "/lib/chaiscript/");
   }
 #endif
+#endif // ifndef CHAISCRIPT_NO_DYNLOAD
 
   return paths;
 }

--- a/unittests/multithreaded_test.cpp
+++ b/unittests/multithreaded_test.cpp
@@ -2,6 +2,9 @@
 
 #include <algorithm>
 
+#ifdef CHAISCRIPT_NO_DYNLOAD
+#include <chaiscript/chaiscript.hpp>
+#endif
 #include <chaiscript/chaiscript_basic.hpp>
 #include <chaiscript/language/chaiscript_parser.hpp>
 
@@ -57,18 +60,22 @@ int main()
   }
 
   std::vector<std::string> modulepaths;
+
+#ifdef CHAISCRIPT_NO_DYNLOAD
+  chaiscript::ChaiScript chai(/* unused */modulepaths, usepaths);
+#else
   modulepaths.push_back("");
   if (modulepath)
   {
     modulepaths.push_back(modulepath);
   }
-
   
   // For this test we are going to load the dynamic stdlib
   // to make sure it continues to work
   chaiscript::ChaiScript_Basic chai(
       std::make_unique<chaiscript::parser::ChaiScript_Parser<chaiscript::eval::Noop_Tracer, chaiscript::optimizer::Optimizer_Default>>(),
       modulepaths,usepaths);
+#endif
 
   std::vector<std::shared_ptr<std::thread> > threads;
 


### PR DESCRIPTION
If CHAISCRIPT_NO_DYNLOAD is defined:
- No need to link with -ldl
- Attempting to call load_module will result in exception
- Attempting to instantiate ChaiScript_Basic without stdlib will result in compilation error
- Options::No_Load_Modules by default
