### PR TITLE
Handle negative numbers in parse_num

### DIFF
--- a/unittests/json_3.chai
+++ b/unittests/json_3.chai
@@ -1,1 +1,2 @@
 assert_equal(from_json("100"), 100)
+assert_equal(from_json("-100"), -100)

--- a/unittests/json_4.chai
+++ b/unittests/json_4.chai
@@ -1,1 +1,2 @@
 assert_equal(from_json("1.234"), 1.234)
+assert_equal(from_json("-1.234"), -1.234)

--- a/unittests/json_9.chai
+++ b/unittests/json_9.chai
@@ -1,2 +1,2 @@
-assert_equal(from_json("[1,2,3]"), [1,2,3])
+assert_equal(from_json("[1,-2,3]"), [1,-2,3])
 


### PR DESCRIPTION
- fix issue #334, where negative numbers loaded from JSON were being
  parsed as 0.
- add unit tests to cover these cases.

Issue this pull request references: #334 

An alternate solution would be to put the handling in `JSONParser::parse_number()`, depending on whether it's important that the underlying `chaiscript::parse_num()` handle negative numbers or not.  I'm not sure how regular ChaiScript numbers are parsed; I guess the preceding '-' for negative numbers must be handled as a negation operator applied to a positive parsed number?

All tests pass (including the new JSON ones I added, which previously would have failed).

I didn't see any significant change in the performance from my changes; in particular, the Integer_Literal_Test and unit.performance.chai tests showed no timing difference (beyond run-to-run variability, e.g. between 6.04 and 6.09 seconds for Integer_Literal_Test).

If you prefer I make the change in JSONParser instead, let me know.  Thanks!
