### PR TITLE
Handle negative numbers in JSONParse::parse_number

### DIFF
--- a/include/chaiscript/utility/json.hpp
+++ b/include/chaiscript/utility/json.hpp
@@ -567,10 +567,13 @@ struct JSONParser {
     std::string val, exp_str;
     char c = '\0';
     bool isDouble = false;
+    bool isNegative = false;
     long exp = 0;
     for (; offset < str.size() ;) {
       c = str[offset++];
-      if( (c == '-') || (c >= '0' && c <= '9') ) {
+      if( c == '-' ) {
+        isNegative = true;
+      } else if( c >= '0' && c <= '9' ) {
         val += c;
       } else if( c == '.' ) {
         val += c; 
@@ -608,12 +611,12 @@ struct JSONParser {
     --offset;
 
     if( isDouble ) {
-      return JSON(chaiscript::parse_num<double>( val ) * std::pow( 10, exp ));
+      return JSON((isNegative?-1:1) * chaiscript::parse_num<double>( val ) * std::pow( 10, exp ));
     } else {
       if( !exp_str.empty() ) {
-        return JSON(static_cast<double>(chaiscript::parse_num<long>( val )) * std::pow( 10, exp ));
+        return JSON((isNegative?-1:1) * static_cast<double>(chaiscript::parse_num<long>( val )) * std::pow( 10, exp ));
       } else {
-        return JSON(chaiscript::parse_num<long>( val ));
+        return JSON((isNegative?-1:1) * chaiscript::parse_num<long>( val ));
       }
     }
   }

--- a/include/chaiscript/utility/json.hpp
+++ b/include/chaiscript/utility/json.hpp
@@ -569,13 +569,15 @@ struct JSONParser {
     bool isDouble = false;
     bool isNegative = false;
     long exp = 0;
+    if( offset < str.size() && str[offset] == '-' ) {
+      isNegative = true;
+      ++offset;
+    }
     for (; offset < str.size() ;) {
       c = str[offset++];
-      if( c == '-' ) {
-        isNegative = true;
-      } else if( c >= '0' && c <= '9' ) {
+      if( c >= '0' && c <= '9' ) {
         val += c;
-      } else if( c == '.' ) {
+      } else if( c == '.' && !isDouble ) {
         val += c; 
         isDouble = true;
       } else {

--- a/unittests/json_3.chai
+++ b/unittests/json_3.chai
@@ -1,1 +1,2 @@
 assert_equal(from_json("100"), 100)
+assert_equal(from_json("-100"), -100)

--- a/unittests/json_4.chai
+++ b/unittests/json_4.chai
@@ -1,2 +1,22 @@
 assert_equal(from_json("1.234"), 1.234)
 assert_equal(from_json("-1.234"), -1.234)
+
+auto caught = false;
+try {
+  from_json("-1-5.3");
+}
+catch(e) {
+  assert_equal("JSON ERROR: Number: unexpected character '-'", e.what());
+  caught = true;
+}
+assert_equal(caught, true);
+
+caught = false;
+try {
+  from_json("-15.3.2");
+}
+catch(e) {
+  assert_equal("JSON ERROR: Number: unexpected character '.'", e.what());
+  caught = true;
+}
+assert_equal(caught, true);

--- a/unittests/json_4.chai
+++ b/unittests/json_4.chai
@@ -1,1 +1,2 @@
 assert_equal(from_json("1.234"), 1.234)
+assert_equal(from_json("-1.234"), -1.234)

--- a/unittests/json_9.chai
+++ b/unittests/json_9.chai
@@ -1,2 +1,2 @@
-assert_equal(from_json("[1,2,3]"), [1,2,3])
+assert_equal(from_json("[1,-2,3]"), [1,-2,3])
 


### PR DESCRIPTION
- fix issue #334, where negative numbers loaded from JSON were being
  parsed as 0.
- add unit tests to cover these cases.

Issue this pull request references: #334

This is my "alternate solution", possibly preferable (?) because it only affects JSON parsing and not the underlying `chaiscript::parse_num()` function.  The existing JSON parsing code assumes chaiscript::parse_num() would handle negative numbers, which it doesn't.  So you need one fix or the other.

All tests pass (including the new JSON ones I added, which previously would have failed).

Please choose this or my other PR (not both). Thanks!