### PR TITLE
fixed PVS-Studio warnings V728

### DIFF
--- a/include/chaiscript/language/chaiscript_parser.hpp
+++ b/include/chaiscript/language/chaiscript_parser.hpp
@@ -995,7 +995,7 @@ namespace chaiscript
           int in_interpolation = 0;
           bool in_quote = false;
 
-          while (m_position.has_more() && ((*m_position != '\"') || ((*m_position == '\"') && (in_interpolation > 0)) ||  ((*m_position == '\"') && (prev_char == '\\')))) {
+          while (m_position.has_more() && ((*m_position != '\"') || (in_interpolation > 0) || (prev_char == '\\'))) {
 
             if (!Eol_()) {
               if (prev_char == '$' && *m_position == '{') {
@@ -1281,7 +1281,7 @@ namespace chaiscript
           char prev_char = *m_position;
           ++m_position;
 
-          while (m_position.has_more() && ((*m_position != '\'') || ((*m_position == '\'') && (prev_char == '\\')))) {
+          while (m_position.has_more() && ((*m_position != '\'') || (prev_char == '\\'))) {
             if (!Eol_()) {
               if (prev_char == '\\') {
                 prev_char = 0;


### PR DESCRIPTION
Issue this pull request references: #

Changes proposed in this pull request

V728 An excessive check can be simplified. The '||' operator is surrounded by opposite expressions '* m_position != '\''' and '* m_position == '\'''.  chaiscript_parser.hpp 
 
