### PR TITLE
from_json: change long to int64_t to remove OS ambiguity

### DIFF
--- a/include/chaiscript/utility/json.hpp
+++ b/include/chaiscript/utility/json.hpp
@@ -131,7 +131,7 @@ class JSON
         }
 
       Internal( double d ) : Float( d ), Type(Class::Floating) {}
-      Internal( long   l ) : Int( l ), Type(Class::Integral) {}
+      Internal( int64_t l ) : Int( l ), Type(Class::Integral) {}
       Internal( bool   b ) : Bool( b ), Type(Class::Boolean) {}
       Internal( std::string s ) : String(std::make_unique<std::string>(std::move(s))), Type(Class::String) {}
       Internal()           : Type(Class::Null) {}
@@ -192,7 +192,7 @@ class JSON
       std::unique_ptr<QuickFlatMap> Map;
       std::unique_ptr<std::string>           String;
       double              Float = 0;
-      long                Int = 0;
+      int64_t             Int = 0;
       bool                Bool = false;
 
       Class Type = Class::Null;
@@ -248,7 +248,7 @@ class JSON
       explicit JSON( T b, typename enable_if<is_same<T,bool>::value>::type* = nullptr ) : internal( static_cast<bool>(b) ) {}
 
     template <typename T>
-      explicit JSON( T i, typename enable_if<is_integral<T>::value && !is_same<T,bool>::value>::type* = nullptr ) : internal( static_cast<long>(i) ) {}
+      explicit JSON( T i, typename enable_if<is_integral<T>::value && !is_same<T,bool>::value>::type* = nullptr ) : internal( static_cast<int64_t>(i) ) {}
 
     template <typename T>
       explicit JSON( T f, typename enable_if<is_floating_point<T>::value>::type* = nullptr ) : internal( static_cast<double>(f) ) {}
@@ -335,8 +335,8 @@ class JSON
       return ok ? internal.Float : 0.0;
     }
 
-    long to_int() const { bool b; return to_int( b ); }
-    long to_int( bool &ok ) const {
+    int64_t to_int() const { bool b; return to_int( b ); }
+    int64_t to_int( bool &ok ) const {
       ok = (internal.Type == Class::Integral);
       return ok ? internal.Int : 0;
     }
@@ -568,7 +568,7 @@ struct JSONParser {
     char c = '\0';
     bool isDouble = false;
     bool isNegative = false;
-    long exp = 0;
+    int64_t exp = 0;
     if( offset < str.size() && str.at(offset) == '-' ) {
       isNegative = true;
       ++offset;
@@ -605,7 +605,7 @@ struct JSONParser {
           break;
 }
       }
-      exp = chaiscript::parse_num<long>( exp_str );
+      exp = chaiscript::parse_num<int64_t>( exp_str );
     }
     else if( offset < str.size() && (!isspace( c ) && c != ',' && c != ']' && c != '}' )) {
       throw std::runtime_error(std::string("JSON ERROR: Number: unexpected character '") + c + "'");
@@ -616,9 +616,9 @@ struct JSONParser {
       return JSON((isNegative?-1:1) * chaiscript::parse_num<double>( val ) * std::pow( 10, exp ));
     } else {
       if( !exp_str.empty() ) {
-        return JSON((isNegative?-1:1) * static_cast<double>(chaiscript::parse_num<long>( val )) * std::pow( 10, exp ));
+        return JSON((isNegative?-1:1) * static_cast<double>(chaiscript::parse_num<int64_t>( val )) * std::pow( 10, exp ));
       } else {
-        return JSON((isNegative?-1:1) * chaiscript::parse_num<long>( val ));
+        return JSON((isNegative?-1:1) * chaiscript::parse_num<int64_t>( val ));
       }
     }
   }

--- a/include/chaiscript/utility/json.hpp
+++ b/include/chaiscript/utility/json.hpp
@@ -570,7 +570,6 @@ struct JSONParser {
     bool isNegative = false;
     int64_t exp = 0;
     bool isExpNegative = false;
-    long exp = 0;
     if( offset < str.size() && str.at(offset) == '-' ) {
       isNegative = true;
       ++offset;


### PR DESCRIPTION
Linux compilers interpret "long" as 64 bit, Visual Studio on Windows interprets "long" as 32 bit. In order to remove ambiguity, from_json should use int64_t rather than long when parsing integers.

Issue this pull request references: #368

Changes proposed in this pull request
json.hpp: switch from "long" to "int64_t"
