### PR TITLE
Fix JSON parsing for floats with negative exponents

### DIFF
--- a/include/chaiscript/utility/json.hpp
+++ b/include/chaiscript/utility/json.hpp
@@ -568,6 +568,7 @@ struct JSONParser {
     char c = '\0';
     bool isDouble = false;
     bool isNegative = false;
+    bool isExpNegative = false;
     long exp = 0;
     if( offset < str.size() && str.at(offset) == '-' ) {
       isNegative = true;
@@ -587,7 +588,7 @@ struct JSONParser {
     if( offset < str.size() && (c == 'E' || c == 'e' )) {
       c = str.at(offset++);
       if( c == '-' ) { 
-        exp_str += '-';
+        isExpNegative = true;
       } else if( c == '+' ) {
         // do nothing
       } else { 
@@ -603,9 +604,9 @@ struct JSONParser {
         }
         else {
           break;
-}
+        }
       }
-      exp = chaiscript::parse_num<long>( exp_str );
+      exp = chaiscript::parse_num<long>( exp_str ) * (isExpNegative?-1:1);
     }
     else if( offset < str.size() && (!isspace( c ) && c != ',' && c != ']' && c != '}' )) {
       throw std::runtime_error(std::string("JSON ERROR: Number: unexpected character '") + c + "'");

--- a/unittests/json_14.chai
+++ b/unittests/json_14.chai
@@ -1,0 +1,5 @@
+assert_equal(from_json("9.9e-02"), 9.9e-02)
+assert_equal(from_json("-13.57e+3"), -13570.0)
+assert_equal(from_json("1E-01"), 0.1)
+assert_equal(from_json("-314159e-5"), -3.14159)
+assert_equal(from_json("5e+04"), 50000)


### PR DESCRIPTION
- also add unit tests to cover some broken (now fixed) cases.

Issue this pull request references: #376
