### PR TITLE
In to_json(), maintain the "type" of empty maps and vectors

### DIFF
--- a/include/chaiscript/utility/json_wrap.hpp
+++ b/include/chaiscript/utility/json_wrap.hpp
@@ -80,7 +80,7 @@ namespace chaiscript
         try {
           const std::map<std::string, Boxed_Value> m = chaiscript::boxed_cast<const std::map<std::string, Boxed_Value> &>(t_bv);
 
-          json::JSON obj;
+          json::JSON obj(json::JSON::Class::Object);
           for (const auto &o : m)
           {
             obj[o.first] = to_json_object(o.second);
@@ -93,7 +93,7 @@ namespace chaiscript
         try {
           const std::vector<Boxed_Value> v = chaiscript::boxed_cast<const std::vector<Boxed_Value> &>(t_bv);
 
-          json::JSON obj;
+          json::JSON obj(json::JSON::Class::Array);
           for (size_t i = 0; i < v.size(); ++i)
           {
             obj[i] = to_json_object(v[i]);
@@ -132,7 +132,7 @@ namespace chaiscript
         try {
           const chaiscript::dispatch::Dynamic_Object &o = boxed_cast<const dispatch::Dynamic_Object &>(t_bv);
 
-          json::JSON obj;
+          json::JSON obj(json::JSON::Class::Object);
           for (const auto &attr : o.get_attrs())
           {
             obj[attr.first] = to_json_object(attr.second);
@@ -141,6 +141,8 @@ namespace chaiscript
         } catch (const chaiscript::exception::bad_boxed_cast &) {
           // not a dynamic object
         }
+
+        if (t_bv.is_null()) return json::JSON(); // a null value
 
         throw std::runtime_error("Unknown object type to convert to JSON");
       }

--- a/unittests/json_15.chai
+++ b/unittests/json_15.chai
@@ -1,0 +1,18 @@
+// Various to_json() tests
+assert_equal(to_json(-13570), "-13570")
+assert_equal(to_json(0.654321), "0.654321")
+assert_equal(to_json("ChaiScript"), "\"ChaiScript\"")
+assert_equal(to_json(true), "true")
+assert_equal(to_json([1, 2, 3]), "[1, 2, 3]")
+assert_equal(to_json(Vector()), "[]") // empty vector
+assert_equal(to_json([]), "[]") // empty vector
+assert_equal(to_json(Map()), "{\n\n}") // empty map
+assert_equal(to_json(Dynamic_Object()), "{\n\n}") // empty object
+
+// Round-trip JSON tests
+assert_equal(from_json(to_json([])), [])
+assert_equal(from_json(to_json(Map())), Map())
+assert_equal(to_json(from_json("null")), "null")
+assert_equal(from_json(to_json(["a": 5, "b": "stuff"])), ["a": 5, "b": "stuff"])
+auto x = [3.5, true, false, "test", [], Vector(), Map()]
+assert_equal(from_json(to_json(x)), x)


### PR DESCRIPTION
Issue this pull request references: #399

Changes proposed in this pull request

- make to_json() with an empty Map, Vector or Dynamic_Object return a similar/compatible type (JSON object or array), rather than "null".
- include the fix for #381 (to_json() support for null values), so that can also be unit tested.
- add unit test to validate to_json().
