### PR TITLE
Critical fix of type_info ordering (less than operator)

### DIFF
--- a/include/chaiscript/dispatchkit/type_info.hpp
+++ b/include/chaiscript/dispatchkit/type_info.hpp
@@ -46,7 +46,7 @@ namespace chaiscript
 
       constexpr Type_Info() = default;
 
-      constexpr bool operator<(const Type_Info &ti) const noexcept
+      bool operator<(const Type_Info &ti) const noexcept
       {
         return m_type_info->before(*ti.m_type_info);
       }

--- a/include/chaiscript/dispatchkit/type_info.hpp
+++ b/include/chaiscript/dispatchkit/type_info.hpp
@@ -48,7 +48,7 @@ namespace chaiscript
 
       constexpr bool operator<(const Type_Info &ti) const noexcept
       {
-        return m_type_info < ti.m_type_info;
+        return m_type_info->before(*ti.m_type_info);
       }
 
       constexpr bool operator!=(const Type_Info &ti) const noexcept


### PR DESCRIPTION
Issue this pull request references: #391 (in part)

Comparing pointers was resulting in random differing behavior between compilations. This fix ensures consistent behavior at least on a given compiler (`before` is implementation specific).
 
