### PR TITLE
Fix CHAISCRIPT_NO_THREADS macro redefinition warning

### DIFF
--- a/unittests/static_chaiscript.cpp
+++ b/unittests/static_chaiscript.cpp
@@ -1,5 +1,7 @@
 
+#ifndef CHAISCRIPT_NO_THREADS
 #define CHAISCRIPT_NO_THREADS
+#endif
 
 /// ChaiScript as a static is unsupported with thread support enabled
 ///


### PR DESCRIPTION
Appeared when compiling with MULTITHREAD_SUPPORT_ENABLED=FALSE.