### PR TITLE
list: Add Random Access

### DIFF
--- a/unittests/list_push_back.chai
+++ b/unittests/list_push_back.chai
@@ -7,6 +7,5 @@ x.push_back("A")
 assert_equal(3, x.front());
 assert_equal("A", x.back());
 
-
-
-
+// Random access with List objects.
+assert_equal("A", x[1])


### PR DESCRIPTION
Changes proposed in this pull request

- Add `[]` selector support to `List()` objects
- This is done through `std::advance()`

This is useful when you want to use a Linked List instead of a vector, but in some cases still would like random access.