### PR TITLE
Empty paths warning

### DIFF
--- a/unittests/multithreaded_test.cpp
+++ b/unittests/multithreaded_test.cpp
@@ -56,7 +56,7 @@ int main()
   
   if(modulepath == nullptr)
   {
-    std::cout << "Warning: environmental variable CHAI_MODULE_PATH not set! " << this_might_affect_test_result;
+    std::cout << "Warning: environmental variable CHAI_MODULE_PATH not set! " << this_might_affect_test_result << "\n";
   }
 
 #ifdef CHAISCRIPT_MSVC

--- a/unittests/multithreaded_test.cpp
+++ b/unittests/multithreaded_test.cpp
@@ -47,16 +47,26 @@ int main()
 
   const char *usepath = getenv("CHAI_USE_PATH");
   const char *modulepath = getenv("CHAI_MODULE_PATH");
+  
+  if(usepath == nullptr)
+  {
+    std::cout << "Warning: usepath not set!\n";
+  }
+  
+  if(modulepath == nullptr)
+  {
+    std::cout << "Warning: modulepath not set!\n";
+  }
 
 #ifdef CHAISCRIPT_MSVC
 #pragma warning(pop)
 #endif
 
   std::vector<std::string> usepaths;
-  usepaths.push_back("");
+  usepaths.emplace_back("");
   if (usepath)
   {
-    usepaths.push_back(usepath);
+    usepaths.emplace_back(usepath);
   }
 
   std::vector<std::string> modulepaths;
@@ -64,10 +74,10 @@ int main()
 #ifdef CHAISCRIPT_NO_DYNLOAD
   chaiscript::ChaiScript chai(/* unused */modulepaths, usepaths);
 #else
-  modulepaths.push_back("");
+  modulepaths.emplace_back("");
   if (modulepath)
   {
-    modulepaths.push_back(modulepath);
+    modulepaths.emplace_back(modulepath);
   }
   
   // For this test we are going to load the dynamic stdlib

--- a/unittests/multithreaded_test.cpp
+++ b/unittests/multithreaded_test.cpp
@@ -47,15 +47,16 @@ int main()
 
   const char *usepath = getenv("CHAI_USE_PATH");
   const char *modulepath = getenv("CHAI_MODULE_PATH");
+  const char *this_might_affect_test_result = "This might have adverse effect on the result of the test.";
   
   if(usepath == nullptr)
   {
-    std::cout << "Warning: usepath not set!\n";
+    std::cout << "Warning: environmental variable CHAI_USE_PATH not set! " << this_might_affect_test_result << "\n";
   }
   
   if(modulepath == nullptr)
   {
-    std::cout << "Warning: modulepath not set!\n";
+    std::cout << "Warning: environmental variable CHAI_MODULE_PATH not set! " << this_might_affect_test_result;
   }
 
 #ifdef CHAISCRIPT_MSVC

--- a/unittests/multithreaded_test.cpp
+++ b/unittests/multithreaded_test.cpp
@@ -49,12 +49,12 @@ int main()
   const char *modulepath = getenv("CHAI_MODULE_PATH");
   const char *this_might_affect_test_result = "This might have adverse effect on the result of the test.";
   
-  if(usepath == nullptr)
+  if(usepath == NULL)
   {
     std::cout << "Warning: environmental variable CHAI_USE_PATH not set! " << this_might_affect_test_result << "\n";
   }
   
-  if(modulepath == nullptr)
+  if(modulepath == NULL)
   {
     std::cout << "Warning: environmental variable CHAI_MODULE_PATH not set! " << this_might_affect_test_result << "\n";
   }
@@ -67,7 +67,7 @@ int main()
   usepaths.emplace_back("");
   if (usepath)
   {
-    usepaths.emplace_back(usepath);
+    usepaths.push_back(usepath);
   }
 
   std::vector<std::string> modulepaths;
@@ -75,10 +75,10 @@ int main()
 #ifdef CHAISCRIPT_NO_DYNLOAD
   chaiscript::ChaiScript chai(/* unused */modulepaths, usepaths);
 #else
-  modulepaths.emplace_back("");
+  modulepaths.push_back("");
   if (modulepath)
   {
-    modulepaths.emplace_back(modulepath);
+    modulepaths.push_back(modulepath);
   }
   
   // For this test we are going to load the dynamic stdlib

--- a/unittests/multithreaded_test.cpp
+++ b/unittests/multithreaded_test.cpp
@@ -111,15 +111,22 @@ int main()
   {
     std::stringstream ss;
     ss << i;
-    if (chai.eval<int>("getvalue(" + ss.str() + ")") != expected_value(4000))
+    try
     {
+      if (chai.eval<int>("getvalue(" + ss.str() + ")") != expected_value(4000))
+      {
+        return EXIT_FAILURE;
+      }
+
+      if (chai.eval<int>("getid(" + ss.str() + ")") != static_cast<int>(i))
+      {
+        return EXIT_FAILURE;
+      }
+    } catch (chaiscript::exception::eval_error &e) {
+      std::cout << e.what();
       return EXIT_FAILURE;
     }
 
-    if (chai.eval<int>("getid(" + ss.str() + ")") != static_cast<int>(i))
-    {
-      return EXIT_FAILURE;
-    }
   }
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
Issue this pull request references: #430

When we forget to set environmental variable CHAI_USE_PATH, the multithreaded_test can fail. To remedy that, I propose to:
 
 - set warning for empty CHAI_USE_PATH value
 - set warning for empty CHAI_MODULE_PATH value
 
