### PR TITLE
Handle BOM in the beginning of the script

### DIFF
--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -206,14 +206,14 @@ namespace chaiscript
 
     /// Skip BOM at the beginning of file
     static bool skip_bom(std::ifstream &infile) {
-        std::streamsize bytes_needed = 3;
-        std::streamsize bytes_read = 0;
+        size_t bytes_needed = 3;
         char buffer[3];
 
-        bytes_read = infile.readsome(buffer, bytes_needed);
+        memset(buffer, '\0', bytes_needed);
 
-        if (bytes_needed == bytes_read
-            && (buffer[0] == '\xef')
+        infile.readsome(buffer, bytes_needed);
+
+        if ((buffer[0] == '\xef')
             && (buffer[1] == '\xbb')
             && (buffer[2] == '\xbf')) {
 

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -206,14 +206,14 @@ namespace chaiscript
 
     /// Skip BOM at the beginning of file
     static bool skip_bom(std::ifstream &infile) {
-        std::streamsize bytes_needed = 3;
-        std::streamsize bytes_read = 0;
-        char buffer[4];
+        size_t bytes_needed = 3;
+        char buffer[3];
 
-        bytes_read = infile.readsome(buffer, bytes_needed);
+        memset(buffer, '\0', bytes_needed);
 
-        if (!bytes_needed < bytes_read
-            && (buffer[0] == '\xef')
+        infile.read(buffer, bytes_needed);
+
+        if ((buffer[0] == '\xef')
             && (buffer[1] == '\xbb')
             && (buffer[2] == '\xbf')) {
 

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -241,6 +241,7 @@ namespace chaiscript
 
       if (skip_bom(infile)) {
           size-=3; // decrement the BOM size from file size, otherwise we'll get parsing errors
+          assert(size >=0 ); //and check if there's more text
       }
 
       if (size == std::streampos(0))

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -207,11 +207,11 @@ namespace chaiscript
 
     /// Skip BOM at the beginning of file
     static bool skip_bom(std::ifstream &infile) {
-        char buffer[4];
+        size_t bytes_needed = 3;
+        std::vector<char> v(bytes_needed);
 
-        memset(buffer, '\0', 4);
-        infile.readsome(buffer, 3);
-        std::string buffer_string(buffer);
+        infile.read(&v[0], static_cast<std::streamsize>(bytes_needed));
+        std::string buffer_string(v.begin(), v.end());
 
         if (chaiscript::parser::detail::Char_Parser_Helper<std::string>::has_utf8_bom(buffer_string)) {
             infile.seekg(3);
@@ -231,12 +231,14 @@ namespace chaiscript
         throw chaiscript::exception::file_not_found_error(t_filename);
       }
 
-      const auto size = infile.tellg();
+      auto size = infile.tellg();
       infile.seekg(0, std::ios::beg);
 
       assert(size >= 0);
 
-      skip_bom(infile);
+      if (skip_bom(infile)) {
+          size-=3; // decrement the BOM size from file size, otherwise we'll get parsing errors
+      }
 
       if (size == std::streampos(0))
       {

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -208,9 +208,9 @@ namespace chaiscript
     static bool skip_bom(std::ifstream &infile) {
         std::streamsize bytes_needed = 3;
         std::streamsize bytes_read = 0;
-        char buffer[3];
+        char buffer[4];
 
-        bytes_read = infile.readsome(&buffer[0], bytes_needed);
+        bytes_read = infile.readsome(buffer, bytes_needed);
 
         if (bytes_needed == bytes_read
             && (buffer[0] == '\xef')

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -206,14 +206,14 @@ namespace chaiscript
 
     /// Skip BOM at the beginning of file
     static bool skip_bom(std::ifstream &infile) {
-        size_t bytes_needed = 3;
+        std::streamsize bytes_needed = 3;
+        std::streamsize bytes_read = 0;
         char buffer[3];
 
-        memset(buffer, '\0', bytes_needed);
+        bytes_read = infile.readsome(buffer, bytes_needed);
 
-        infile.readsome(buffer, bytes_needed);
-
-        if ((buffer[0] == '\xef')
+        if (bytes_needed == bytes_read
+            && (buffer[0] == '\xef')
             && (buffer[1] == '\xbb')
             && (buffer[2] == '\xbf')) {
 

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -211,7 +211,7 @@ namespace chaiscript
 
         memset(buffer, '\0', bytes_needed);
 
-        infile.read(buffer, bytes_needed);
+        infile.read(buffer, static_cast<std::streamsize>(bytes_needed));
 
         if ((buffer[0] == '\xef')
             && (buffer[1] == '\xbb')

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -208,7 +208,7 @@ namespace chaiscript
     static bool skip_bom(std::ifstream &infile) {
         std::streamsize bytes_needed = 3;
         std::streamsize bytes_read = 0;
-        char buffer[3] = { '\0' };
+        char buffer[3];
 
         bytes_read = infile.readsome(buffer, bytes_needed);
 

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -212,7 +212,7 @@ namespace chaiscript
 
         bytes_read = infile.readsome(buffer, bytes_needed);
 
-        if (bytes_needed == bytes_read
+        if (!bytes_needed < bytes_read
             && (buffer[0] == '\xef')
             && (buffer[1] == '\xbb')
             && (buffer[2] == '\xbf')) {

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -52,7 +52,6 @@
 
 
 #include "../dispatchkit/exception_specification.hpp"
-#include "chaiscript_parser.hpp"
 
 namespace chaiscript
 {
@@ -213,7 +212,11 @@ namespace chaiscript
         infile.read(&v[0], static_cast<std::streamsize>(bytes_needed));
         std::string buffer_string(v.begin(), v.end());
 
-        if (chaiscript::parser::detail::Char_Parser_Helper<std::string>::has_utf8_bom(buffer_string)) {
+        if ((buffer_string.size() > 2)
+            && (buffer_string[0] == '\xef')
+            && (buffer_string[1] == '\xbb')
+            && (buffer_string[2] == '\xbf')) {
+
             infile.seekg(3);
             return true;
         }

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -212,7 +212,7 @@ namespace chaiscript
         infile.read(&v[0], static_cast<std::streamsize>(bytes_needed));
         std::string buffer_string(v.begin(), v.end());
 
-        if ((buffer_string.size() > 2)
+        if (!infile.eof()
             && (buffer_string[0] == '\xef')
             && (buffer_string[1] == '\xbb')
             && (buffer_string[2] == '\xbf')) {

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -206,14 +206,11 @@ namespace chaiscript
 
     /// Skip BOM at the beginning of file
     static bool skip_bom(std::ifstream &infile) {
-        size_t bytes_needed = 3;
-        size_t bytes_read = 0;
-        char buffer[256];
+        std::streamsize bytes_needed = 3;
+        std::streamsize bytes_read = 0;
+        char buffer[3];
 
-        while (bytes_read < bytes_needed) {
-            infile >> buffer;
-            bytes_read++;
-        }
+        bytes_read = infile.readsome(buffer, bytes_needed);
 
         if (bytes_needed == bytes_read
             && (buffer[0] == '\xef')
@@ -242,7 +239,7 @@ namespace chaiscript
 
       assert(size >= 0);
 
-      if (size >= 3 && skip_bom(infile)) {
+      if (skip_bom(infile)) {
           size-=3; // decrement the BOM size from file size, otherwise we'll get parsing errors
           assert(size >=0 ); //and check if there's more text
       }

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -208,7 +208,7 @@ namespace chaiscript
     static bool skip_bom(std::ifstream &infile) {
         std::streamsize bytes_needed = 3;
         std::streamsize bytes_read = 0;
-        char buffer[3];
+        char buffer[3] = { '\0' };
 
         bytes_read = infile.readsome(buffer, bytes_needed);
 

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -207,15 +207,18 @@ namespace chaiscript
     /// Skip BOM at the beginning of file
     static bool skip_bom(std::ifstream &infile) {
         size_t bytes_needed = 3;
-        std::vector<char> v(bytes_needed);
+        size_t bytes_read = 0;
+        char buffer[256];
 
-        infile.read(&v[0], static_cast<std::streamsize>(bytes_needed));
-        std::string buffer_string(v.begin(), v.end());
+        while (bytes_read < bytes_needed) {
+            infile >> buffer;
+            bytes_read++;
+        }
 
-        if (!infile.eof()
-            && (buffer_string[0] == '\xef')
-            && (buffer_string[1] == '\xbb')
-            && (buffer_string[2] == '\xbf')) {
+        if (bytes_needed == bytes_read
+            && (buffer[0] == '\xef')
+            && (buffer[1] == '\xbb')
+            && (buffer[2] == '\xbf')) {
 
             infile.seekg(3);
             return true;
@@ -239,7 +242,7 @@ namespace chaiscript
 
       assert(size >= 0);
 
-      if (skip_bom(infile)) {
+      if (size >= 3 && skip_bom(infile)) {
           size-=3; // decrement the BOM size from file size, otherwise we'll get parsing errors
           assert(size >=0 ); //and check if there's more text
       }

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -52,6 +52,7 @@
 
 
 #include "../dispatchkit/exception_specification.hpp"
+#include "chaiscript_parser.hpp"
 
 namespace chaiscript
 {
@@ -204,6 +205,23 @@ namespace chaiscript
       m_engine.add(fun([this](const std::string& t_namespace_name) { import(t_namespace_name); }), "import");
     }
 
+    /// Skip BOM at the beginning of file
+    static bool skip_bom(std::ifstream &infile) {
+        char buffer[4];
+
+        memset(buffer, '\0', 4);
+        infile.readsome(buffer, 3);
+        std::string buffer_string(buffer);
+
+        if (chaiscript::parser::detail::Char_Parser_Helper<std::string>::has_utf8_bom(buffer_string)) {
+            infile.seekg(3);
+            return true;
+        }
+
+        infile.seekg(0);
+
+        return false;
+    }
 
     /// Helper function for loading a file
     static std::string load_file(const std::string &t_filename) {
@@ -217,6 +235,8 @@ namespace chaiscript
       infile.seekg(0, std::ios::beg);
 
       assert(size >= 0);
+
+      skip_bom(infile);
 
       if (size == std::streampos(0))
       {

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -210,7 +210,7 @@ namespace chaiscript
         std::streamsize bytes_read = 0;
         char buffer[3];
 
-        bytes_read = infile.readsome(buffer, bytes_needed);
+        bytes_read = infile.readsome(&buffer[0], bytes_needed);
 
         if (bytes_needed == bytes_read
             && (buffer[0] == '\xef')

--- a/include/chaiscript/language/chaiscript_parser.hpp
+++ b/include/chaiscript/language/chaiscript_parser.hpp
@@ -114,6 +114,12 @@ namespace chaiscript
           // little SFINAE trick to avoid base class
           return Char_Parser_Helper<std::true_type>::u8str_from_ll(val);
         }
+        
+        static bool has_utf8_bom(const std::string &t_input)
+        {
+          //skip UTF-8 BOM
+          return ((t_input.size() > 3) && (t_input[0] == '\xef') && (t_input[1] == '\xbb' && t_input[2] == '\xbf'));
+        }
       };
     }
 
@@ -2562,18 +2568,15 @@ namespace chaiscript
       AST_NodePtr parse_internal(const std::string &t_input, std::string t_fname) {
         m_position = Position(t_input.begin(), t_input.end());
         m_filename = std::make_shared<std::string>(std::move(t_fname));
+        
+        if (detail::Char_Parser_Helper<std::string>::has_utf8_bom(t_input)) {
+           throw exception::eval_error("UTF-8 in user provided input!");
+        }
 
         if ((t_input.size() > 1) && (t_input[0] == '#') && (t_input[1] == '!')) {
           while (m_position.has_more() && (!Eol())) {
             ++m_position;
           }
-        }
-
-        //skip UTF-8 BOM
-        if ((t_input.size() > 3) && (t_input[0] == '\xef') && (t_input[1] == '\xbb' && t_input[2] == '\xbf')) {
-            while(m_position.has_more() && (m_position.col < 4)) {
-                ++m_position;
-            }
         }
 
         if (Statements(true)) {

--- a/include/chaiscript/language/chaiscript_parser.hpp
+++ b/include/chaiscript/language/chaiscript_parser.hpp
@@ -114,12 +114,6 @@ namespace chaiscript
           // little SFINAE trick to avoid base class
           return Char_Parser_Helper<std::true_type>::u8str_from_ll(val);
         }
-
-        static bool has_utf8_bom(const std::string &t_input)
-        {
-          //skip UTF-8 BOM
-          return ((t_input.size() > 2) && (t_input[0] == '\xef') && (t_input[1] == '\xbb' && t_input[2] == '\xbf'));
-        }
       };
     }
 

--- a/include/chaiscript/language/chaiscript_parser.hpp
+++ b/include/chaiscript/language/chaiscript_parser.hpp
@@ -526,6 +526,7 @@ namespace chaiscript
 
       /// Skips ChaiScript whitespace, which means space and tab, but not cr/lf
       /// jespada: Modified SkipWS to skip optionally CR ('\n') and/or LF+CR ("\r\n")
+      /// AlekMosingiewicz: Added exception when illegal character detected
       bool SkipWS(bool skip_cr=false) {
         bool retval = false;
 

--- a/include/chaiscript/language/chaiscript_parser.hpp
+++ b/include/chaiscript/language/chaiscript_parser.hpp
@@ -530,6 +530,9 @@ namespace chaiscript
         bool retval = false;
 
         while (m_position.has_more()) {
+          if(static_cast<size_t>(*m_position) > 0x7e) {
+            throw exception::eval_error("Illegal character", File_Position(m_position.line, m_position.col), *m_filename);
+          }
           auto end_line = (*m_position != 0) && ((*m_position == '\n') || (*m_position == '\r' && *(m_position+1) == '\n'));
 
           if ( char_in_alphabet(*m_position,detail::white_alphabet) || (skip_cr && end_line)) {
@@ -2569,9 +2572,9 @@ namespace chaiscript
         m_position = Position(t_input.begin(), t_input.end());
         m_filename = std::make_shared<std::string>(std::move(t_fname));
 
-        if (detail::Char_Parser_Helper<std::string>::has_utf8_bom(t_input)) {
-           throw exception::eval_error("UTF-8 in user provided input!");
-        }
+        //if (detail::Char_Parser_Helper<std::string>::has_utf8_bom(t_input)) {
+        //   throw exception::eval_error("UTF-8 in user provided input!");
+        //}
 
         if ((t_input.size() > 1) && (t_input[0] == '#') && (t_input[1] == '!')) {
           while (m_position.has_more() && (!Eol())) {

--- a/include/chaiscript/language/chaiscript_parser.hpp
+++ b/include/chaiscript/language/chaiscript_parser.hpp
@@ -114,11 +114,11 @@ namespace chaiscript
           // little SFINAE trick to avoid base class
           return Char_Parser_Helper<std::true_type>::u8str_from_ll(val);
         }
-        
+
         static bool has_utf8_bom(const std::string &t_input)
         {
           //skip UTF-8 BOM
-          return ((t_input.size() > 3) && (t_input[0] == '\xef') && (t_input[1] == '\xbb' && t_input[2] == '\xbf'));
+          return ((t_input.size() > 2) && (t_input[0] == '\xef') && (t_input[1] == '\xbb' && t_input[2] == '\xbf'));
         }
       };
     }
@@ -2568,7 +2568,7 @@ namespace chaiscript
       AST_NodePtr parse_internal(const std::string &t_input, std::string t_fname) {
         m_position = Position(t_input.begin(), t_input.end());
         m_filename = std::make_shared<std::string>(std::move(t_fname));
-        
+
         if (detail::Char_Parser_Helper<std::string>::has_utf8_bom(t_input)) {
            throw exception::eval_error("UTF-8 in user provided input!");
         }

--- a/include/chaiscript/language/chaiscript_parser.hpp
+++ b/include/chaiscript/language/chaiscript_parser.hpp
@@ -2569,6 +2569,13 @@ namespace chaiscript
           }
         }
 
+        //skip UTF-8 BOM
+        if ((t_input.size() > 3) && (t_input[0] == '\xef') && (t_input[1] == '\xbb' && t_input[2] == '\xbf')) {
+            while(m_position.has_more() && (m_position.col < 4)) {
+                ++m_position;
+            }
+        }
+
         if (Statements(true)) {
           if (m_position.has_more()) {
             throw exception::eval_error("Unparsed input", File_Position(m_position.line, m_position.col), *m_filename);

--- a/include/chaiscript/language/chaiscript_parser.hpp
+++ b/include/chaiscript/language/chaiscript_parser.hpp
@@ -525,7 +525,7 @@ namespace chaiscript
         bool retval = false;
 
         while (m_position.has_more()) {
-          if(static_cast<size_t>(*m_position) > 0x7e) {
+          if(static_cast<unsigned char>(*m_position) > 0x7e) {
             throw exception::eval_error("Illegal character", File_Position(m_position.line, m_position.col), *m_filename);
           }
           auto end_line = (*m_position != 0) && ((*m_position == '\n') || (*m_position == '\r' && *(m_position+1) == '\n'));
@@ -2598,10 +2598,6 @@ namespace chaiscript
       AST_NodePtr parse_internal(const std::string &t_input, std::string t_fname) {
         m_position = Position(t_input.begin(), t_input.end());
         m_filename = std::make_shared<std::string>(std::move(t_fname));
-
-        //if (detail::Char_Parser_Helper<std::string>::has_utf8_bom(t_input)) {
-        //   throw exception::eval_error("UTF-8 in user provided input!");
-        //}
 
         if ((t_input.size() > 1) && (t_input[0] == '#') && (t_input[1] == '!')) {
           while (m_position.has_more() && (!Eol())) {

--- a/unittests/compiled_tests.cpp
+++ b/unittests/compiled_tests.cpp
@@ -355,12 +355,7 @@ TEST_CASE("Functor cast")
 TEST_CASE("BOM at beginning of string")
 {
   chaiscript::ChaiScript_Basic chai(create_chaiscript_stdlib(),create_chaiscript_parser());
-
-  chai.add(chaiscript::fun(&functor_cast_test_call), "test_call");
-
-  chai.eval("def func() { return \"Hello World\"; };");
-
-  CHECK(chai.eval<std::string>("\xef\xbb\xbf(func())") == "Hello World");
+  CHECK_THROWS_AS(chai.eval<std::string>("\xef\xbb\xbfprint \"Hello World\""), chaiscript::exception::eval_error);
 }
 
 

--- a/unittests/compiled_tests.cpp
+++ b/unittests/compiled_tests.cpp
@@ -360,9 +360,7 @@ TEST_CASE("BOM at beginning of string")
 
   chai.eval("def func() { return \"Hello World\"; };");
 
-  std::string result = chai.eval<std::string>("\xef\xbb\xbf(func())");
-
-  CHECK(result.compare(std::string("Hello World")) == 0);
+  CHECK(chai.eval<std::string>("\xef\xbb\xbf(func())") == "Hello World");
 }
 
 

--- a/unittests/compiled_tests.cpp
+++ b/unittests/compiled_tests.cpp
@@ -352,6 +352,18 @@ TEST_CASE("Functor cast")
   CHECK(d == 3 * 6);
 }
 
+TEST_CASE("BOM at beginning of string")
+{
+  chaiscript::ChaiScript_Basic chai(create_chaiscript_stdlib(),create_chaiscript_parser());
+
+  chai.add(chaiscript::fun(&functor_cast_test_call), "test_call");
+
+  chai.eval("def func() { return \"Hello World\"; };");
+
+  std::string result = chai.eval<std::string>("\xef\xbb\xbf(func())");
+
+  CHECK(result.compare(std::string("Hello World")) == 0);
+}
 
 
 int set_state_test_myfun()

--- a/unittests/compiled_tests.cpp
+++ b/unittests/compiled_tests.cpp
@@ -352,12 +352,23 @@ TEST_CASE("Functor cast")
   CHECK(d == 3 * 6);
 }
 
-TEST_CASE("Non-ASCII characters in string")
+TEST_CASE("Non-ASCII characters in the middle of string")
 {
   chaiscript::ChaiScript_Basic chai(create_chaiscript_stdlib(),create_chaiscript_parser());
   CHECK_THROWS_AS(chai.eval<std::string>("prin\xeft \"Hello World\""), chaiscript::exception::eval_error);
 }
 
+TEST_CASE("Non-ASCII characters in the beginning of string")
+{
+    chaiscript::ChaiScript_Basic chai(create_chaiscript_stdlib(),create_chaiscript_parser());
+    CHECK_THROWS_AS(chai.eval<std::string>("\xefprint \"Hello World\""), chaiscript::exception::eval_error);
+}
+
+TEST_CASE("Non-ASCII characters in the end of string")
+{
+    chaiscript::ChaiScript_Basic chai(create_chaiscript_stdlib(),create_chaiscript_parser());
+    CHECK_THROWS_AS(chai.eval<std::string>("print \"Hello World\"\xef"), chaiscript::exception::eval_error);
+}
 
 int set_state_test_myfun()
 {

--- a/unittests/compiled_tests.cpp
+++ b/unittests/compiled_tests.cpp
@@ -370,6 +370,12 @@ TEST_CASE("Non-ASCII characters in the end of string")
     CHECK_THROWS_AS(chai.eval<std::string>("print \"Hello World\"\xef"), chaiscript::exception::eval_error);
 }
 
+TEST_CASE("BOM in string")
+{
+    chaiscript::ChaiScript_Basic chai(create_chaiscript_stdlib(),create_chaiscript_parser());
+    CHECK_THROWS_AS(chai.eval<std::string>("\xef\xbb\xbfprint \"Hello World\""), chaiscript::exception::eval_error);
+}
+
 int set_state_test_myfun()
 {
   return 2;

--- a/unittests/compiled_tests.cpp
+++ b/unittests/compiled_tests.cpp
@@ -352,10 +352,10 @@ TEST_CASE("Functor cast")
   CHECK(d == 3 * 6);
 }
 
-TEST_CASE("BOM at beginning of string")
+TEST_CASE("Non-ASCII characters in string")
 {
   chaiscript::ChaiScript_Basic chai(create_chaiscript_stdlib(),create_chaiscript_parser());
-  CHECK_THROWS_AS(chai.eval<std::string>("\xef\xbb\xbfprint \"Hello World\""), chaiscript::exception::eval_error);
+  CHECK_THROWS_AS(chai.eval<std::string>("prin\xeft \"Hello World\""), chaiscript::exception::eval_error);
 }
 
 

--- a/unittests/eval_file_with_bom.chai
+++ b/unittests/eval_file_with_bom.chai
@@ -1,0 +1,2 @@
+eval_file("file_with_bom.inc")
+assert_true(alwaysTrue())

--- a/unittests/file_with_bom.inc
+++ b/unittests/file_with_bom.inc
@@ -1,0 +1,3 @@
+﻿def alwaysTrue() {
+   return true
+}


### PR DESCRIPTION
Issue this pull request references: #436

Changes proposed in this pull request

 - detect BOM in the same way a symbolic link is detected before the parsing begins and skip it
 
