### PR TITLE
Fix: added 'static' to thread_local variable in chaiscript/chaiscript…

### DIFF
--- a/include/chaiscript/chaiscript_threading.hpp
+++ b/include/chaiscript/chaiscript_threading.hpp
@@ -107,7 +107,7 @@ namespace chaiscript
             /// does there is no possible way to recover
             static std::unordered_map<const void*, T> &t() noexcept
             {
-              thread_local std::unordered_map<const void *, T> my_t;
+              static thread_local std::unordered_map<const void *, T> my_t;
               return my_t;
             }
         };


### PR DESCRIPTION
…_threading.hpp

Because it's a singleton and should be one instance per thread, without it will be singleton per call,
also it won't compile on VS2017 15.8.9
The error:
chaiscript\include\chaiscript\chaiscript_threading.hpp(107): error C2480: 'my_t': 'thread' is only valid for data items of static extent

Issue this pull request references: #462

Changes proposed in this pull request
Bugfix
