### PR TITLE
Add pair_conversion registration helper with unit test

### DIFF
--- a/include/chaiscript/dispatchkit/type_conversions.hpp
+++ b/include/chaiscript/dispatchkit/type_conversions.hpp
@@ -654,6 +654,23 @@ namespace chaiscript
 
       return chaiscript::make_shared<detail::Type_Conversion_Base, detail::Type_Conversion_Impl<decltype(func)>>(user_type<std::map<std::string, Boxed_Value>>(), user_type<To>(), func);
     }
+
+  template<typename Left, typename Right>
+    Type_Conversion pair_conversion()
+    {
+      auto func = [](const Boxed_Value &t_bv) -> Boxed_Value {
+        const std::pair<Boxed_Value, Boxed_Value> &from_pair = detail::Cast_Helper<const std::pair<Boxed_Value, Boxed_Value> &>::cast(t_bv, nullptr);
+
+        auto pair = std::make_pair(
+          detail::Cast_Helper<Left>::cast(from_pair.first, nullptr),
+          detail::Cast_Helper<Right>::cast(from_pair.second, nullptr)
+        );
+
+        return Boxed_Value(std::move(pair));
+      };
+
+      return chaiscript::make_shared<detail::Type_Conversion_Base, detail::Type_Conversion_Impl<decltype(func)>>(user_type<std::pair<Boxed_Value, Boxed_Value>>(), user_type<std::pair<Left, Right>>(), func);
+    }
 }
 
 

--- a/unittests/compiled_tests.cpp
+++ b/unittests/compiled_tests.cpp
@@ -996,6 +996,29 @@ TEST_CASE("Map conversions")
 }
 
 
+TEST_CASE("Pair conversions")
+{
+  chaiscript::ChaiScript_Basic chai(create_chaiscript_stdlib(),create_chaiscript_parser());
+  chai.add(chaiscript::pair_conversion<std::string, std::string>());
+  chai.add(chaiscript::pair_conversion<int, double>());
+
+  {
+    const auto p = chai.eval<std::pair<std::string, std::string>>(R"cs(
+      Pair("chai", "script");
+    )cs");
+    CHECK(p.first == std::string{"chai"});
+    CHECK(p.second == "script");
+  }
+  {
+    const auto p = chai.eval<std::pair<int, double>>(R"cs(
+      Pair(5, 3.14);
+    )cs");
+    CHECK(p.first == 5);
+    CHECK(p.second == Approx(3.14));
+  }
+}
+
+
 TEST_CASE("Parse floats with non-posix locale")
 {
 #ifdef CHAISCRIPT_MSVC


### PR DESCRIPTION
Issue this pull request references: [Discussion in forum thread](http://discourse.chaiscript.com/t/convert-complex-chaiscript-types-e-g-map-of-map-to-user-defined-types/143/7)


Changes proposed in this pull request

 - add a `pair_conversion()` registration helper, analogous to the existing `vector_conversion()` and `map_conversion()` helpers.
 - implement a compiled unit test for the new feature.
 