### PR TITLE
Update cheatsheet.md: Adding Lambda correction.

### DIFF
--- a/cheatsheet.md
+++ b/cheatsheet.md
@@ -66,7 +66,7 @@ chai.add(chaiscript::fun(static_cast<int(Derived::*)>(&Derived::data)), "data");
 
 ```
 chai.add(
-  chaiscript::fun<std::string (bool)>(
+  chaiscript::fun<std::function<std::string (bool)>>(
     [](bool type) {
       if (type) { return "x"; }
       else { return "y"; }


### PR DESCRIPTION
Currently, the example where a lambda function was added to chaiscript didn't work for me.
I use g++7, g++8,g++9 both with c++14 and c++17 mode.
It doesn't work either in clang++-7.

If the lambda is wrapped into a std::function<> it will work again!


I have tested it also for Chaiscript 6, 6.1, 6.1.1 and for develop. It didn't work!