### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,19 @@ templates.  It has been tested with gcc 4.9 and clang 3.6 (with libcxx).
 For more information see the build 
 [dashboard](http://chaiscript.com/ChaiScript-BuildResults/index.html).
 
+Installation using vcpkg
+========================
+
+You can download and install ChaiScript using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install chaiscript
+
+The ChaiScript port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 Usage
 =====
 


### PR DESCRIPTION
ChaiScript is available as a port in [vcpkg](https://github.com/Microsoft/vcpkg), a C++ library manager that simplifies installation for ChaiScript and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build ChaiScript, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/chaiscript/portfile.cmake). We try to keep the library maintained as close as possible to the original library.
