### PR TITLE
Use CMAKE_INSTALL_LIBDIR instead of lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,7 +426,7 @@ if(BUILD_TESTING)
     target_link_libraries(multifile_test ${LIBS})
     add_test(NAME MultiFile_Test COMMAND multifile_test)
 
-    install(TARGETS test_module RUNTIME DESTINATION bin LIBRARY DESTINATION LIBDIR/chaiscript)
+    install(TARGETS test_module RUNTIME DESTINATION bin LIBRARY DESTINATION ${LIBDIR}/chaiscript)
   endif()
 endif()
 
@@ -439,7 +439,7 @@ if(BUILD_LIBFUZZ_TESTER)
 endif()
 
 
-install(TARGETS chai chaiscript_stdlib-${CHAI_VERSION} ${MODULES} RUNTIME DESTINATION bin LIBRARY DESTINATION LIBDIR/chaiscript)
+install(TARGETS chai chaiscript_stdlib-${CHAI_VERSION} ${MODULES} RUNTIME DESTINATION bin LIBRARY DESTINATION ${LIBDIR}/chaiscript)
 
 install(DIRECTORY include/chaiscript DESTINATION include
   PATTERN "*.hpp"
@@ -460,6 +460,6 @@ install(DIRECTORY samples DESTINATION share/chaiscript
 
 configure_file(contrib/pkgconfig/chaiscript.pc.in lib/pkgconfig/chaiscript.pc @ONLY)
 install(FILES "${chaiscript_BINARY_DIR}/lib/pkgconfig/chaiscript.pc"
-        DESTINATION LIBDIR/pkgconfig)
+        DESTINATION ${LIBDIR}/pkgconfig)
 
     

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,7 +426,7 @@ if(BUILD_TESTING)
     target_link_libraries(multifile_test ${LIBS})
     add_test(NAME MultiFile_Test COMMAND multifile_test)
 
-    install(TARGETS test_module RUNTIME DESTINATION bin LIBRARY DESTINATION "${LIBDIR}/chaiscript")
+    install(TARGETS test_module RUNTIME DESTINATION bin LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}/chaiscript")
   endif()
 endif()
 
@@ -439,7 +439,7 @@ if(BUILD_LIBFUZZ_TESTER)
 endif()
 
 
-install(TARGETS chai chaiscript_stdlib-${CHAI_VERSION} ${MODULES} RUNTIME DESTINATION bin LIBRARY DESTINATION "${LIBDIR}/chaiscript")
+install(TARGETS chai chaiscript_stdlib-${CHAI_VERSION} ${MODULES} RUNTIME DESTINATION bin LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}/chaiscript")
 
 install(DIRECTORY include/chaiscript DESTINATION include
   PATTERN "*.hpp"
@@ -460,6 +460,6 @@ install(DIRECTORY samples DESTINATION share/chaiscript
 
 configure_file(contrib/pkgconfig/chaiscript.pc.in lib/pkgconfig/chaiscript.pc @ONLY)
 install(FILES "${chaiscript_BINARY_DIR}/lib/pkgconfig/chaiscript.pc"
-        DESTINATION "${LIBDIR}/pkgconfig")
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
     

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,7 +426,7 @@ if(BUILD_TESTING)
     target_link_libraries(multifile_test ${LIBS})
     add_test(NAME MultiFile_Test COMMAND multifile_test)
 
-    install(TARGETS test_module RUNTIME DESTINATION bin LIBRARY DESTINATION ${LIBDIR}/chaiscript)
+    install(TARGETS test_module RUNTIME DESTINATION bin LIBRARY DESTINATION "${LIBDIR}/chaiscript")
   endif()
 endif()
 
@@ -439,7 +439,7 @@ if(BUILD_LIBFUZZ_TESTER)
 endif()
 
 
-install(TARGETS chai chaiscript_stdlib-${CHAI_VERSION} ${MODULES} RUNTIME DESTINATION bin LIBRARY DESTINATION ${LIBDIR}/chaiscript)
+install(TARGETS chai chaiscript_stdlib-${CHAI_VERSION} ${MODULES} RUNTIME DESTINATION bin LIBRARY DESTINATION "${LIBDIR}/chaiscript")
 
 install(DIRECTORY include/chaiscript DESTINATION include
   PATTERN "*.hpp"
@@ -460,6 +460,6 @@ install(DIRECTORY samples DESTINATION share/chaiscript
 
 configure_file(contrib/pkgconfig/chaiscript.pc.in lib/pkgconfig/chaiscript.pc @ONLY)
 install(FILES "${chaiscript_BINARY_DIR}/lib/pkgconfig/chaiscript.pc"
-        DESTINATION ${LIBDIR}/pkgconfig)
+        DESTINATION "${LIBDIR}/pkgconfig")
 
     

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,7 +426,7 @@ if(BUILD_TESTING)
     target_link_libraries(multifile_test ${LIBS})
     add_test(NAME MultiFile_Test COMMAND multifile_test)
 
-    install(TARGETS test_module RUNTIME DESTINATION bin LIBRARY DESTINATION lib/chaiscript)
+    install(TARGETS test_module RUNTIME DESTINATION bin LIBRARY DESTINATION LIBDIR/chaiscript)
   endif()
 endif()
 
@@ -439,7 +439,7 @@ if(BUILD_LIBFUZZ_TESTER)
 endif()
 
 
-install(TARGETS chai chaiscript_stdlib-${CHAI_VERSION} ${MODULES} RUNTIME DESTINATION bin LIBRARY DESTINATION lib/chaiscript)
+install(TARGETS chai chaiscript_stdlib-${CHAI_VERSION} ${MODULES} RUNTIME DESTINATION bin LIBRARY DESTINATION LIBDIR/chaiscript)
 
 install(DIRECTORY include/chaiscript DESTINATION include
   PATTERN "*.hpp"
@@ -458,8 +458,8 @@ install(DIRECTORY samples DESTINATION share/chaiscript
   PATTERN "*/.git*" EXCLUDE
   PATTERN "*~" EXCLUDE)
 
-configure_file(contrib/pkgconfig/chaiscript.pc.in lib/pkgconfig/chaiscript.pc @ONLY)
+configure_file(contrib/pkgconfig/chaiscript.pc.in LIBDIR/pkgconfig/chaiscript.pc @ONLY)
 install(FILES "${chaiscript_BINARY_DIR}/lib/pkgconfig/chaiscript.pc"
-        DESTINATION lib/pkgconfig)
+        DESTINATION LIBDIR/pkgconfig)
 
     

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,7 +458,7 @@ install(DIRECTORY samples DESTINATION share/chaiscript
   PATTERN "*/.git*" EXCLUDE
   PATTERN "*~" EXCLUDE)
 
-configure_file(contrib/pkgconfig/chaiscript.pc.in LIBDIR/pkgconfig/chaiscript.pc @ONLY)
+configure_file(contrib/pkgconfig/chaiscript.pc.in lib/pkgconfig/chaiscript.pc @ONLY)
 install(FILES "${chaiscript_BINARY_DIR}/lib/pkgconfig/chaiscript.pc"
         DESTINATION LIBDIR/pkgconfig)
 


### PR DESCRIPTION
 In Linux, the library should be installed to /usr/lib64 on 64bit machine

Issue this pull request references: #

Changes proposed in this pull request

 -
 -
 -
 
