### PR TITLE
Potential fix for issue ChaiScript#481

### DIFF
--- a/include/chaiscript/dispatchkit/function_call_detail.hpp
+++ b/include/chaiscript/dispatchkit/function_call_detail.hpp
@@ -41,7 +41,7 @@ namespace chaiscript
 
           Ret call(const Function_Params &params, const Type_Conversions_State &t_state)
           {
-            if constexpr (std::is_arithmetic_v<Ret>) {
+            if constexpr (std::is_arithmetic_v<Ret> && !std::is_same_v<std::remove_cv_t<std::remove_reference_t<Ret>>, bool>) {
               return Boxed_Number(dispatch::dispatch(m_funcs, params, t_state)).get_as<Ret>();
             } else if constexpr (std::is_same_v<void, Ret>) {
               dispatch::dispatch(m_funcs, params, t_state);


### PR DESCRIPTION
When a script function returning a boolean is called from C++ code, ChaiScript tries to initialize a `Boxed_Number` with the returned value. A *bad any cast* exception is then raised.

The proposed modification checks if the return value is a (possibly *cv-ref* qualified) `bool`, before instantiating the `Boxed_Number` (leading to a `boxed_cast` instead).
