### PR TITLE
Add unit test covering lambdas returning boolean

### DIFF
--- a/include/chaiscript/dispatchkit/function_call_detail.hpp
+++ b/include/chaiscript/dispatchkit/function_call_detail.hpp
@@ -41,7 +41,7 @@ namespace chaiscript
 
           Ret call(const Function_Params &params, const Type_Conversions_State &t_state)
           {
-            if constexpr (std::is_arithmetic_v<Ret>) {
+            if constexpr (std::is_arithmetic_v<Ret> && !std::is_same_v<std::remove_reference_t<std::remove_cv_t<Ret>>, bool>) {
               return Boxed_Number(dispatch::dispatch(m_funcs, params, t_state)).get_as<Ret>();
             } else if constexpr (std::is_same_v<void, Ret>) {
               dispatch::dispatch(m_funcs, params, t_state);

--- a/include/chaiscript/dispatchkit/function_call_detail.hpp
+++ b/include/chaiscript/dispatchkit/function_call_detail.hpp
@@ -41,7 +41,7 @@ namespace chaiscript
 
           Ret call(const Function_Params &params, const Type_Conversions_State &t_state)
           {
-            if constexpr (std::is_arithmetic_v<Ret> && !std::is_same_v<std::remove_reference_t<std::remove_cv_t<Ret>>, bool>) {
+            if constexpr (std::is_arithmetic_v<Ret>) {
               return Boxed_Number(dispatch::dispatch(m_funcs, params, t_state)).get_as<Ret>();
             } else if constexpr (std::is_same_v<void, Ret>) {
               dispatch::dispatch(m_funcs, params, t_state);

--- a/unittests/compiled_tests.cpp
+++ b/unittests/compiled_tests.cpp
@@ -50,6 +50,26 @@ TEST_CASE("C++11 Lambdas Can Be Registered")
   CHECK(chai.eval<std::string>("f2()") == "world");
 }
 
+TEST_CASE("Lambdas can return boolean")
+{
+  chaiscript::ChaiScript_Basic chai(create_chaiscript_stdlib(),create_chaiscript_parser());
+
+  // check lambdas returning bool from chaiscript:
+  std::function<bool ()> chai_function;
+
+  CHECK_NOTHROW(chai_function = chai.eval<std::function<bool ()>>("fun() { 42 != 0 }"));
+
+  bool result = false;
+  CHECK_NOTHROW(result = chai_function());
+
+  CHECK(result == true);
+
+  // check lambdas returning bool from C++:
+  auto cpp_function = [](int x) { return x == 42; };
+  CHECK_NOTHROW(chai.add(chaiscript::fun(cpp_function), "cpp_function"));
+  CHECK_NOTHROW(result = chai.eval<bool>("cpp_function(314)"));
+  CHECK(result == false);
+}
 
 // dynamic_object tests
 TEST_CASE("Dynamic_Object attributes can be shared with C++")


### PR DESCRIPTION
Issue this pull request references: #481

Changes proposed in this pull request:

 - implemented unit test which is validating whether a lambda from Chaiscript could return a boolean value without throwing any exception,
 - the same test case is checking also whether lambda with boolean return value
could be called peacefully from Chaiscript.
 
After pull request #503 will be resolved, this test will pass; for now it's producing 2 failed checks:

```
/home/draghan/programming/ChaiScript/my/ChaiScript/cmake-build-debug/compiled_tests

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compiled_tests is a Catch v2.2.2 host application.
Run with -? for options

-------------------------------------------------------------------------------
Lambdas can return boolean
-------------------------------------------------------------------------------
/home/draghan/programming/ChaiScript/my/ChaiScript/unittests/compiled_tests.cpp:53
...............................................................................

/home/draghan/programming/ChaiScript/my/ChaiScript/unittests/compiled_tests.cpp:63: FAILED:
  CHECK_NOTHROW( result = chai_function() )
due to unexpected exception with message:
  bad any cast

/home/draghan/programming/ChaiScript/my/ChaiScript/unittests/compiled_tests.cpp:65: FAILED:
  CHECK( result == true )
with expansion:
  false == true

Hello World
Object_Copy_Count_Test()
Object_Copy_Count_Test(Object_Copy_Count_Test &&)
~Object_Copy_Count_Test()
~Object_Copy_Count_Test()
10
10
Test
15
15
making vector
adding config item
returning vector
St6vectorI25Returned_Converted_ConfigSaIS0_EE
Info: 1 0x1bfc240
num_iterations 5
something_else 10
a_string string
a_function 3
1.3
found at 1, 2
A
ok
5
===============================================================================
test cases:  51 |  50 passed | 1 failed
assertions: 190 | 188 passed | 2 failed


Process finished with exit code 2
```