### PR TITLE
Fix for warnings: by-copy capture of ‘this’  and unused-local-typedefs.

### DIFF
--- a/include/chaiscript/dispatchkit/boxed_number.hpp
+++ b/include/chaiscript/dispatchkit/boxed_number.hpp
@@ -49,6 +49,15 @@ namespace chaiscript
 #pragma warning(disable : 4244 4018 4389 4146 4365 4267 4242)
 #endif
 
+//
+// Disable the switch completeness warnings because they raise a false positive, in the 
+// operations. 
+//
+#ifdef CHAISCRIPT_MSVC
+#pragma warning(push)
+#pragma warning(disable : 4062)
+#endif
+
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push

--- a/include/chaiscript/dispatchkit/dispatchkit.hpp
+++ b/include/chaiscript/dispatchkit/dispatchkit.hpp
@@ -1303,8 +1303,8 @@ namespace chaiscript
           const auto lhssize = lhsparamtypes.size();
           const auto rhssize = rhsparamtypes.size();
 
-          constexpr const auto boxed_type = user_type<Boxed_Value>();
-          constexpr const auto boxed_pod_type = user_type<Boxed_Number>();
+          constexpr auto const boxed_type = user_type<Boxed_Value>();
+          constexpr auto const boxed_pod_type = user_type<Boxed_Number>();
 
           for (size_t i = 1; i < lhssize && i < rhssize; ++i)
           {

--- a/include/chaiscript/dispatchkit/proxy_functions.hpp
+++ b/include/chaiscript/dispatchkit/proxy_functions.hpp
@@ -77,7 +77,7 @@ namespace chaiscript
         std::vector<Boxed_Value> convert(Function_Params t_params, const Type_Conversions_State &t_conversions) const
         {
           auto vals = t_params.to_vector();
-          constexpr auto dynamic_object_type_info = user_type<Dynamic_Object>();
+          constexpr const auto dynamic_object_type_info = user_type<Dynamic_Object>();
           for (size_t i = 0; i < vals.size(); ++i)
           {
             const auto &name = m_types[i].first;
@@ -117,7 +117,7 @@ namespace chaiscript
         // second result: needs conversions
         std::pair<bool, bool> match(const Function_Params &vals, const Type_Conversions_State &t_conversions) const noexcept
         {
-          constexpr auto dynamic_object_type_info = user_type<Dynamic_Object>();
+          constexpr const auto dynamic_object_type_info = user_type<Dynamic_Object>();
           bool needs_conversion = false;
 
           if (!m_has_types) { return std::make_pair(true, needs_conversion); }
@@ -252,9 +252,9 @@ namespace chaiscript
 
         static bool compare_type_to_param(const Type_Info &ti, const Boxed_Value &bv, const Type_Conversions_State &t_conversions) noexcept
         {
-          constexpr auto boxed_value_ti = user_type<Boxed_Value>();
-          constexpr auto boxed_number_ti = user_type<Boxed_Number>();
-          constexpr auto function_ti = user_type<std::shared_ptr<const Proxy_Function_Base>>();
+          constexpr const auto boxed_value_ti = user_type<Boxed_Value>();
+          constexpr const auto boxed_number_ti = user_type<Boxed_Number>();
+          constexpr const auto function_ti = user_type<std::shared_ptr<const Proxy_Function_Base>>();
 
           if (ti.is_undef()
               || ti.bare_equal(boxed_value_ti)

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -156,7 +156,7 @@ namespace chaiscript
 
 
       m_engine.add(fun(
-            [=, this](const dispatch::Proxy_Function_Base &t_fun, const std::vector<Boxed_Value> &t_params) -> Boxed_Value {
+            [this](const dispatch::Proxy_Function_Base &t_fun, const std::vector<Boxed_Value> &t_params) -> Boxed_Value {
               Type_Conversions_State s(this->m_engine.conversions(), this->m_engine.conversions().conversion_saves());
               return t_fun(Function_Params{t_params}, s);
             }), "call");
@@ -168,7 +168,7 @@ namespace chaiscript
       m_engine.add(fun([this](const std::string &t_type_name){ return m_engine.get_type(t_type_name, true); }), "type");
 
       m_engine.add(fun(
-            [=, this](const Type_Info &t_from, const Type_Info &t_to, const std::function<Boxed_Value (const Boxed_Value &)> &t_func) {
+            [this](const Type_Info &t_from, const Type_Info &t_to, const std::function<Boxed_Value (const Boxed_Value &)> &t_func) {
               m_engine.add(chaiscript::type_conversion(t_from, t_to, t_func));
             }
           ), "add_type_conversion");

--- a/include/chaiscript/language/chaiscript_eval.hpp
+++ b/include/chaiscript/language/chaiscript_eval.hpp
@@ -331,7 +331,6 @@ namespace chaiscript
 
           Boxed_Value fn(this->children[0]->eval(t_ss));
 
-          using ConstFunctionTypePtr = const dispatch::Proxy_Function_Base *;
           try {
             return (*t_ss->boxed_cast<const dispatch::Proxy_Function_Base *>(fn))(Function_Params{params}, t_ss.conversions());
           }


### PR DESCRIPTION
There are three warnings when compiling with GCC 7.4.1 or clang 5.0.1 or VisualStudio/appveyor

  1. warning: explicit by-copy capture of ‘this’ redundant with by-copy capture default
  2. warning: typedef ... locally defined but not used [-Wunused-local-typedefs]
  3. warning C4062 : enumerator ... in switch of enum ... is not handled

This change removes [2] and compact the lambda in [1].

The [3] is handled disabling the warning check in code with a pragma.

Issue this pull request references: #

Changes proposed in this pull request

 -
 -
 -
 
