### PR TITLE
pass details to eval_exceptions for getting an object

### DIFF
--- a/include/chaiscript/language/chaiscript_eval.hpp
+++ b/include/chaiscript/language/chaiscript_eval.hpp
@@ -306,7 +306,7 @@ namespace chaiscript
             } else {
                 const std::string& filename = "Unknown";
                 throw exception::eval_error(what, file_position, filename);
-              }
+            }
           }
         }
 

--- a/include/chaiscript/language/chaiscript_eval.hpp
+++ b/include/chaiscript/language/chaiscript_eval.hpp
@@ -298,7 +298,15 @@ namespace chaiscript
             return t_ss.get_object(this->text, m_loc);
           }
           catch (std::exception &) {
-            throw exception::eval_error("Can not find object: " + this->text);
+            File_Position file_position(this->location.start.line, this->location.start.column);
+            std::string what = std::string("Can not find object: ") + this->text;
+            if (this->location.filename != nullptr) {
+                const std::string& filename = *this->location.filename.get();
+                throw exception::eval_error(what, file_position, filename);
+            } else {
+                const std::string& filename = "Unknown";
+                throw exception::eval_error(what, file_position, filename);
+              }
           }
         }
 


### PR DESCRIPTION
Changes proposed in this pull request:

- This adds the current file, line and column to an exception thrown during object lookup.

Tested with `chai.eval("puts(bogusvar[0])")` and `chai.eval_file(file_containing_the_same)` and it printed the line, column and filename/`__EVAL__`.

I am using v5.8.6 if that changes anything due to VS2013.
