### PR TITLE
AppVeyor / MSVC / CI nastyness.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,9 @@ if(MSVC)
   add_definitions(/std:c++latest /W4 /w14545 /w34242 /w34254 /w34287 /w44263 /w44265 /w44296 /w44311 /w44826 /we4289 /w14546 /w14547 /w14549 /w14555 /w14619 /w14905 /w14906 /w14928)
 
   add_definitions(/std:c++17)
-
+  
+  # Let's get ALL the diagnostic info
+  add_definitions(/v:diag)
 
   if (MSVC_VERSION STREQUAL "1800")
     # VS2013 doesn't have magic statics

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ image:
   - Visual Studio 2019
 environment:
   matrix:
-  - VS_VERSION: "Visual Studio 19"
+  - VS_VERSION: "Visual Studio 16 2019"
 build_script:
 - cmd: >-
     mkdir build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 version: 6.1.x.{build}
 image:
-  - Visual Studio 2017
+  - Visual Studio 2019
 environment:
   matrix:
-  - VS_VERSION: "Visual Studio 15"
+  - VS_VERSION: "Visual Studio 19"
 build_script:
 - cmd: >-
     mkdir build

--- a/include/chaiscript/dispatchkit/proxy_functions.hpp
+++ b/include/chaiscript/dispatchkit/proxy_functions.hpp
@@ -80,7 +80,7 @@ namespace chaiscript
         std::vector<Boxed_Value> convert(Function_Params t_params, const Type_Conversions_State &t_conversions) const
         {
           auto vals = t_params.to_vector();
-          constexpr auto intid { typeid(int) };
+          const auto * intid { &typeid(int) };
           constexpr Type_Info IAMATEST(false,false,false,false,false,intid,intid);
           std::cout << IAMATEST.name() << std::endl;
           constexpr auto dynamic_object_type_info = user_type<Dynamic_Object>();

--- a/include/chaiscript/dispatchkit/proxy_functions.hpp
+++ b/include/chaiscript/dispatchkit/proxy_functions.hpp
@@ -81,7 +81,7 @@ namespace chaiscript
         {
           auto vals = t_params.to_vector();
           
-          const std::type_info * floop { &typeid(int) };
+          constexpr std::type_info * floop { &typeid(int) };
           std:.cout << floop->name() << std::endl; // should print 'i' or smth like that
           
           constexpr auto dynamic_object_type_info = user_type<Dynamic_Object>();

--- a/include/chaiscript/dispatchkit/proxy_functions.hpp
+++ b/include/chaiscript/dispatchkit/proxy_functions.hpp
@@ -80,9 +80,11 @@ namespace chaiscript
         std::vector<Boxed_Value> convert(Function_Params t_params, const Type_Conversions_State &t_conversions) const
         {
           auto vals = t_params.to_vector();
-          const auto * intid { &typeid(int) };
-          constexpr Type_Info IAMATEST(false,false,false,false,false,intid,intid);
+          
+          const std::type_info * floop { &typeid(int) };
+          constexpr Type_Info IAMATEST(false,false,false,false,false,floop,floop);
           std::cout << IAMATEST.name() << std::endl;
+          
           constexpr auto dynamic_object_type_info = user_type<Dynamic_Object>();
           for (size_t i = 0; i < vals.size(); ++i)
           {

--- a/include/chaiscript/dispatchkit/proxy_functions.hpp
+++ b/include/chaiscript/dispatchkit/proxy_functions.hpp
@@ -81,7 +81,7 @@ namespace chaiscript
         {
           auto vals = t_params.to_vector();
           
-          const std::type_info * floop { &typeid(int) };
+          const std::type_info * floop = &typeid(Boxed_Value);
           constexpr Type_Info IAMATEST(false,false,false,false,false,floop,floop);
           std::cout << IAMATEST.name() << std::endl;
           

--- a/include/chaiscript/dispatchkit/proxy_functions.hpp
+++ b/include/chaiscript/dispatchkit/proxy_functions.hpp
@@ -81,7 +81,7 @@ namespace chaiscript
         {
           auto vals = t_params.to_vector();
           
-          constexpr std::type_info * floop { &typeid(int) };
+          const std::type_info * floop { &typeid(int) };
           std::cout << floop->name() << std::endl; // should print 'i' or smth like that
           
           constexpr auto dynamic_object_type_info = user_type<Dynamic_Object>();

--- a/include/chaiscript/dispatchkit/proxy_functions.hpp
+++ b/include/chaiscript/dispatchkit/proxy_functions.hpp
@@ -82,7 +82,7 @@ namespace chaiscript
           auto vals = t_params.to_vector();
           
           constexpr std::type_info * floop { &typeid(int) };
-          std:.cout << floop->name() << std::endl; // should print 'i' or smth like that
+          std::cout << floop->name() << std::endl; // should print 'i' or smth like that
           
           constexpr auto dynamic_object_type_info = user_type<Dynamic_Object>();
           for (size_t i = 0; i < vals.size(); ++i)

--- a/include/chaiscript/dispatchkit/proxy_functions.hpp
+++ b/include/chaiscript/dispatchkit/proxy_functions.hpp
@@ -29,6 +29,9 @@
 #include "dynamic_object.hpp"
 #include "function_params.hpp"
 
+// TODO: remove me - just for testing
+#include <iostream>
+
 namespace chaiscript {
 class Type_Conversions;
 namespace exception {
@@ -77,6 +80,8 @@ namespace chaiscript
         std::vector<Boxed_Value> convert(Function_Params t_params, const Type_Conversions_State &t_conversions) const
         {
           auto vals = t_params.to_vector();
+          constexpr Type_Info IAMATEST{};
+          std::cout << IAMATEST.name() << std::endl;
           constexpr auto dynamic_object_type_info = user_type<Dynamic_Object>();
           for (size_t i = 0; i < vals.size(); ++i)
           {

--- a/include/chaiscript/dispatchkit/proxy_functions.hpp
+++ b/include/chaiscript/dispatchkit/proxy_functions.hpp
@@ -81,10 +81,8 @@ namespace chaiscript
         {
           auto vals = t_params.to_vector();
           
-          const std::type_info * floop = &typeid(int);
+          const std::type_info * floop { &typeid(int) };
           std:.cout << floop->name() << std::endl; // should print 'i' or smth like that
-          constexpr Type_Info IAMATEST(false,false,false,false,false,floop,floop);
-          std::cout << IAMATEST.name() << std::endl;
           
           constexpr auto dynamic_object_type_info = user_type<Dynamic_Object>();
           for (size_t i = 0; i < vals.size(); ++i)

--- a/include/chaiscript/dispatchkit/proxy_functions.hpp
+++ b/include/chaiscript/dispatchkit/proxy_functions.hpp
@@ -80,7 +80,8 @@ namespace chaiscript
         std::vector<Boxed_Value> convert(Function_Params t_params, const Type_Conversions_State &t_conversions) const
         {
           auto vals = t_params.to_vector();
-          constexpr Type_Info IAMATEST(false,false,false,false,false,typeid(int),typeid(int));
+          constexpr auto intid { typeid(int) };
+          constexpr Type_Info IAMATEST(false,false,false,false,false,intid,intid);
           std::cout << IAMATEST.name() << std::endl;
           constexpr auto dynamic_object_type_info = user_type<Dynamic_Object>();
           for (size_t i = 0; i < vals.size(); ++i)

--- a/include/chaiscript/dispatchkit/proxy_functions.hpp
+++ b/include/chaiscript/dispatchkit/proxy_functions.hpp
@@ -81,7 +81,8 @@ namespace chaiscript
         {
           auto vals = t_params.to_vector();
           
-          const std::type_info * floop = &typeid(Boxed_Value);
+          const std::type_info * floop = &typeid(int);
+          std:.cout << floop->name() << std::endl; // should print 'i' or smth like that
           constexpr Type_Info IAMATEST(false,false,false,false,false,floop,floop);
           std::cout << IAMATEST.name() << std::endl;
           

--- a/include/chaiscript/dispatchkit/proxy_functions.hpp
+++ b/include/chaiscript/dispatchkit/proxy_functions.hpp
@@ -80,7 +80,7 @@ namespace chaiscript
         std::vector<Boxed_Value> convert(Function_Params t_params, const Type_Conversions_State &t_conversions) const
         {
           auto vals = t_params.to_vector();
-          constexpr Type_Info IAMATEST{};
+          constexpr Type_Info IAMATEST(false,false,false,false,false,typeid(int),typeid(int));
           std::cout << IAMATEST.name() << std::endl;
           constexpr auto dynamic_object_type_info = user_type<Dynamic_Object>();
           for (size_t i = 0; i < vals.size(); ++i)

--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -139,36 +139,36 @@ namespace chaiscript
         add(t_lib);
       }
 
-      m_engine.add(fun([this](){ m_engine.dump_system(); }), "dump_system");
-      m_engine.add(fun([this](const Boxed_Value &t_bv){ m_engine.dump_object(t_bv); }), "dump_object");
-      m_engine.add(fun([this](const Boxed_Value &t_bv, const std::string &t_type){ return m_engine.is_type(t_bv, t_type); }), "is_type");
-      m_engine.add(fun([this](const Boxed_Value &t_bv){ return m_engine.type_name(t_bv); }), "type_name");
-      m_engine.add(fun([this](const std::string &t_f){ return m_engine.function_exists(t_f); }), "function_exists");
-      m_engine.add(fun([this](){ return m_engine.get_function_objects(); }), "get_functions");
-      m_engine.add(fun([this](){ return m_engine.get_scripting_objects(); }), "get_objects");
+      m_engine.add(fun([&](){ m_engine.dump_system(); }), "dump_system");
+      m_engine.add(fun([&](const Boxed_Value &t_bv){ m_engine.dump_object(t_bv); }), "dump_object");
+      m_engine.add(fun([&](const Boxed_Value &t_bv, const std::string &t_type){ return m_engine.is_type(t_bv, t_type); }), "is_type");
+      m_engine.add(fun([&](const Boxed_Value &t_bv){ return m_engine.type_name(t_bv); }), "type_name");
+      m_engine.add(fun([&](const std::string &t_f){ return m_engine.function_exists(t_f); }), "function_exists");
+      m_engine.add(fun([&](){ return m_engine.get_function_objects(); }), "get_functions");
+      m_engine.add(fun([&](){ return m_engine.get_scripting_objects(); }), "get_objects");
 
       m_engine.add(
           dispatch::make_dynamic_proxy_function(
-              [this](const Function_Params &t_params) {
+              [&](const Function_Params &t_params) {
                 return m_engine.call_exists(t_params);
               })
           , "call_exists");
 
 
       m_engine.add(fun(
-            [this](const dispatch::Proxy_Function_Base &t_fun, const std::vector<Boxed_Value> &t_params) -> Boxed_Value {
+            [&](const dispatch::Proxy_Function_Base &t_fun, const std::vector<Boxed_Value> &t_params) -> Boxed_Value {
               Type_Conversions_State s(this->m_engine.conversions(), this->m_engine.conversions().conversion_saves());
               return t_fun(Function_Params{t_params}, s);
             }), "call");
 
 
-      m_engine.add(fun([this](const Type_Info &t_ti){ return m_engine.get_type_name(t_ti); }), "name");
+      m_engine.add(fun([&](const Type_Info &t_ti){ return m_engine.get_type_name(t_ti); }), "name");
 
-      m_engine.add(fun([this](const std::string &t_type_name, bool t_throw){ return m_engine.get_type(t_type_name, t_throw); }), "type");
-      m_engine.add(fun([this](const std::string &t_type_name){ return m_engine.get_type(t_type_name, true); }), "type");
+      m_engine.add(fun([&](const std::string &t_type_name, bool t_throw){ return m_engine.get_type(t_type_name, t_throw); }), "type");
+      m_engine.add(fun([&](const std::string &t_type_name){ return m_engine.get_type(t_type_name, true); }), "type");
 
       m_engine.add(fun(
-            [this](const Type_Info &t_from, const Type_Info &t_to, const std::function<Boxed_Value (const Boxed_Value &)> &t_func) {
+            [&](const Type_Info &t_from, const Type_Info &t_to, const std::function<Boxed_Value (const Boxed_Value &)> &t_func) {
               m_engine.add(chaiscript::type_conversion(t_from, t_to, t_func));
             }
           ), "add_type_conversion");
@@ -178,31 +178,31 @@ namespace chaiscript
       if (std::find(t_opts.begin(), t_opts.end(), Options::No_Load_Modules) == t_opts.end()
           && std::find(t_opts.begin(), t_opts.end(), Options::Load_Modules) != t_opts.end()) 
       {
-        m_engine.add(fun([this](const std::string &t_module, const std::string &t_file){ return load_module(t_module, t_file); }), "load_module");
-        m_engine.add(fun([this](const std::string &t_module){ return load_module(t_module); }), "load_module");
+        m_engine.add(fun([&](const std::string &t_module, const std::string &t_file){ return load_module(t_module, t_file); }), "load_module");
+        m_engine.add(fun([&](const std::string &t_module){ return load_module(t_module); }), "load_module");
       }
 
       if (std::find(t_opts.begin(), t_opts.end(), Options::No_External_Scripts) == t_opts.end()
           && std::find(t_opts.begin(), t_opts.end(), Options::External_Scripts) != t_opts.end())
       {
-        m_engine.add(fun([this](const std::string &t_file){ return use(t_file); }), "use");
-        m_engine.add(fun([this](const std::string &t_file){ return internal_eval_file(t_file); }), "eval_file");
+        m_engine.add(fun([&](const std::string &t_file){ return use(t_file); }), "use");
+        m_engine.add(fun([&](const std::string &t_file){ return internal_eval_file(t_file); }), "eval_file");
       }
 
-      m_engine.add(fun([this](const std::string &t_str){ return internal_eval(t_str); }), "eval");
-      m_engine.add(fun([this](const AST_Node &t_ast){ return eval(t_ast); }), "eval");
+      m_engine.add(fun([&](const std::string &t_str){ return internal_eval(t_str); }), "eval");
+      m_engine.add(fun([&](const AST_Node &t_ast){ return eval(t_ast); }), "eval");
 
-      m_engine.add(fun([this](const std::string &t_str, const bool t_dump){ return parse(t_str, t_dump); }), "parse");
-      m_engine.add(fun([this](const std::string &t_str){ return parse(t_str); }), "parse");
+      m_engine.add(fun([&](const std::string &t_str, const bool t_dump){ return parse(t_str, t_dump); }), "parse");
+      m_engine.add(fun([&](const std::string &t_str){ return parse(t_str); }), "parse");
 
 
-      m_engine.add(fun([this](const Boxed_Value &t_bv, const std::string &t_name){ add_global_const(t_bv, t_name); }), "add_global_const");
-      m_engine.add(fun([this](const Boxed_Value &t_bv, const std::string &t_name){ add_global(t_bv, t_name); }), "add_global");
-      m_engine.add(fun([this](const Boxed_Value &t_bv, const std::string &t_name){ set_global(t_bv, t_name); }), "set_global");
+      m_engine.add(fun([&](const Boxed_Value &t_bv, const std::string &t_name){ add_global_const(t_bv, t_name); }), "add_global_const");
+      m_engine.add(fun([&](const Boxed_Value &t_bv, const std::string &t_name){ add_global(t_bv, t_name); }), "add_global");
+      m_engine.add(fun([&](const Boxed_Value &t_bv, const std::string &t_name){ set_global(t_bv, t_name); }), "set_global");
 
       // why this unused parameter to Namespace?
-      m_engine.add(fun([this](const std::string& t_namespace_name) { register_namespace([](Namespace& /*space*/) {}, t_namespace_name); import(t_namespace_name); }), "namespace");
-      m_engine.add(fun([this](const std::string& t_namespace_name) { import(t_namespace_name); }), "import");
+      m_engine.add(fun([&](const std::string& t_namespace_name) { register_namespace([](Namespace& /*space*/) {}, t_namespace_name); import(t_namespace_name); }), "namespace");
+      m_engine.add(fun([&](const std::string& t_namespace_name) { import(t_namespace_name); }), "import");
     }
 
     /// Skip BOM at the beginning of file


### PR DESCRIPTION
<s>Just some poking around to see what AppVeyor has to say.</s>

`Type_Info` containing `const std::type_info *` with `&typeid()` being used in a `constexpr` makes MSVC explode.

https://godbolt.org/z/zxeTav
https://developercommunity.visualstudio.com/content/problem/462846/address-of-typeid-is-not-constexpr.html
https://developercommunity.visualstudio.com/content/problem/957737/constexpr-typeid-in-aggregate.html

Don't merge, this is just stuff to find the problem, no solutions here.