### PR TITLE
Fixes for VS2019 and C++17 compilation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 version: 6.1.x.{build}
 image:
-  - Visual Studio 2017
+  - Visual Studio 2019
 environment:
   matrix:
-  - VS_VERSION: "Visual Studio 15"
+  - VS_VERSION: "Visual Studio 16"
 build_script:
 - cmd: >-
     mkdir build

--- a/include/chaiscript/chaiscript_defines.hpp
+++ b/include/chaiscript/chaiscript_defines.hpp
@@ -271,7 +271,7 @@ namespace chaiscript {
 
 
   template<typename ... T>
-  [[nodiscard]] auto make_vector(T && ... t)
+  [[nodiscard]] auto make_vector(T &&... t) -> std::vector<std::common_type_t<std::decay_t<T>...>>
   {
     using container_type = 
       std::vector<std::common_type_t<std::decay_t<T>...>>;

--- a/include/chaiscript/dispatchkit/boxed_number.hpp
+++ b/include/chaiscript/dispatchkit/boxed_number.hpp
@@ -185,7 +185,9 @@ namespace chaiscript
             return const_var(c_lhs * c_rhs);
           case Operators::Opers::difference:
             return const_var(c_lhs - c_rhs);
-        }
+          default:
+            break;
+          }
 
 
         if constexpr (!std::is_floating_point<LHS>::value && !std::is_floating_point<RHS>::value) {
@@ -203,7 +205,9 @@ namespace chaiscript
               return const_var(c_lhs | c_rhs);
             case Operators::Opers::bitwise_xor:
               return const_var(c_lhs ^ c_rhs);
-          }
+            default:
+              break;
+            }
         }
 
         if (t_lhs) {
@@ -224,7 +228,9 @@ namespace chaiscript
             case Operators::Opers::assign_difference:
               *t_lhs -= c_rhs;
               return t_bv;
-          }
+            default:
+              break;
+            }
 
           if constexpr (!std::is_floating_point<LHS>::value && !std::is_floating_point<RHS>::value) {
             switch (t_oper) {
@@ -247,7 +253,9 @@ namespace chaiscript
               case Operators::Opers::assign_bitwise_xor:
                 *t_lhs ^= c_rhs;
                 return t_bv;
-            }
+              default:
+                break;
+              }
           }
         }
 
@@ -299,7 +307,9 @@ namespace chaiscript
                 case Operators::Opers::pre_decrement:
                   --(*lhs);
                   return t_lhs;
-              }
+                default:
+                  break;
+                }
             }
 
             switch (t_oper) {
@@ -307,13 +317,17 @@ namespace chaiscript
                 return const_var(-c_lhs);
               case Operators::Opers::unary_plus:
                 return const_var(+c_lhs);
-            }
+              default:
+                break;
+              }
 
             if constexpr (!std::is_floating_point_v<std::decay_t<decltype(c_lhs)>>) {
               switch (t_oper) {
                 case Operators::Opers::bitwise_complement:
                   return const_var(~c_lhs);
-              }
+                default:
+                  break;
+                }
             }
 
             throw chaiscript::detail::exception::bad_any_cast();

--- a/include/chaiscript/dispatchkit/dispatchkit.hpp
+++ b/include/chaiscript/dispatchkit/dispatchkit.hpp
@@ -1303,8 +1303,8 @@ namespace chaiscript
           const auto lhssize = lhsparamtypes.size();
           const auto rhssize = rhsparamtypes.size();
 
-          constexpr const auto boxed_type = user_type<Boxed_Value>();
-          constexpr const auto boxed_pod_type = user_type<Boxed_Number>();
+          const auto boxed_type = user_type<Boxed_Value>();
+          const auto boxed_pod_type = user_type<Boxed_Number>();
 
           for (size_t i = 1; i < lhssize && i < rhssize; ++i)
           {

--- a/include/chaiscript/dispatchkit/function_call_detail.hpp
+++ b/include/chaiscript/dispatchkit/function_call_detail.hpp
@@ -39,7 +39,7 @@ namespace chaiscript
           {
           }
 
-          Ret call(const Function_Params &params, const Type_Conversions_State &t_state)
+          Ret call(const chaiscript::Function_Params &params, const Type_Conversions_State &t_state)
           {
             if constexpr (std::is_arithmetic_v<Ret>) {
               return Boxed_Number(dispatch::dispatch(m_funcs, params, t_state)).get_as<Ret>();
@@ -57,11 +57,11 @@ namespace chaiscript
 
             if (m_conversions) {
               Type_Conversions_State state(*m_conversions, m_conversions->conversion_saves());
-              return call(Function_Params{params}, state);
+              return call(chaiscript::Function_Params{params}, state);
             } else {
               Type_Conversions conv;
               Type_Conversions_State state(conv, conv.conversion_saves());
-              return call(Function_Params{params}, state);
+              return call(chaiscript::Function_Params{params}, state);
             }
 
           }

--- a/include/chaiscript/dispatchkit/function_params.hpp
+++ b/include/chaiscript/dispatchkit/function_params.hpp
@@ -76,7 +76,7 @@ namespace chaiscript {
 
   // Constructor specialization for array of size 0
   template<>
-  constexpr Function_Params::Function_Params(const std::array<Boxed_Value, size_t{0}> &a)
+  constexpr Function_Params::Function_Params(const std::array<Boxed_Value, size_t{0}> & /* a */)
     : m_begin(nullptr), m_end(nullptr)
   {
   }

--- a/include/chaiscript/dispatchkit/function_params.hpp
+++ b/include/chaiscript/dispatchkit/function_params.hpp
@@ -36,7 +36,7 @@ namespace chaiscript {
 
       template<size_t Size>
       constexpr explicit Function_Params(const std::array<Boxed_Value, Size> &a)
-        : m_begin(std::begin(a)), m_end(std::end(a))
+        : m_begin(&*std::begin(a)), m_end(&*std::end(a))
       {
       }
 

--- a/include/chaiscript/dispatchkit/function_params.hpp
+++ b/include/chaiscript/dispatchkit/function_params.hpp
@@ -40,12 +40,6 @@ namespace chaiscript {
       {
       }
 
-      template<>
-      constexpr explicit Function_Params(const std::array<Boxed_Value, size_t{0}> &a)
-        : m_begin(nullptr), m_end(nullptr)
-      {
-      }
-
       [[nodiscard]] constexpr const Boxed_Value &operator[](const std::size_t t_i) const noexcept {
         return m_begin[t_i];
       }
@@ -79,6 +73,13 @@ namespace chaiscript {
       const Boxed_Value *m_end = nullptr;
 
   };
+
+  // Constructor specialization for array of size 0
+  template<>
+  constexpr Function_Params::Function_Params(const std::array<Boxed_Value, size_t{0}> &a)
+    : m_begin(nullptr), m_end(nullptr)
+  {
+  }
 
 }
 

--- a/include/chaiscript/dispatchkit/function_params.hpp
+++ b/include/chaiscript/dispatchkit/function_params.hpp
@@ -30,13 +30,19 @@ namespace chaiscript {
       }
 
       explicit Function_Params(const std::vector<Boxed_Value> &vec)
-        : m_begin(&vec.front()), m_end(&vec.front() + vec.size())
+        : m_begin(vec.empty() ? nullptr : &vec.front()), m_end(vec.empty() ? nullptr : &vec.front() + vec.size())
       {
       }
 
       template<size_t Size>
       constexpr explicit Function_Params(const std::array<Boxed_Value, Size> &a)
-        : m_begin(&*std::begin(a)), m_end(&*std::end(a))
+        : m_begin(&a.front()), m_end(&a.front() + Size)
+      {
+      }
+
+      template<>
+      constexpr explicit Function_Params(const std::array<Boxed_Value, size_t{0}> &a)
+        : m_begin(nullptr), m_end(nullptr)
       {
       }
 

--- a/include/chaiscript/dispatchkit/function_signature.hpp
+++ b/include/chaiscript/dispatchkit/function_signature.hpp
@@ -4,121 +4,142 @@
 #include <type_traits>
 
 namespace chaiscript::dispatch::detail {
-  template<typename ... Param>
-    struct Function_Params
-    {
-    };
 
-  template<typename Ret, typename Params, bool IsNoExcept = false, bool IsMember = false, bool IsMemberObject = false, bool IsObject = false>
-    struct Function_Signature {
-      using Param_Types = Params;
-      using Return_Type = Ret;
-      constexpr static const bool is_object = IsObject;
-      constexpr static const bool is_member_object = IsMemberObject;
-      constexpr static const bool is_noexcept = IsNoExcept;
-      template<typename T>
-        constexpr Function_Signature(T &&) noexcept {}
-      constexpr Function_Signature() noexcept = default;
-    };
+template<typename... Param>
+struct Function_Params
+{
+};
 
-  // Free functions
+template<typename Ret, typename Params, bool IsNoExcept = false, bool IsMember = false, bool IsMemberObject = false, bool IsObject = false>
+struct Function_Signature
+{
+  using Param_Types = Params;
+  using Return_Type = Ret;
+  constexpr static const bool is_object = IsObject;
+  constexpr static const bool is_member_object = IsMemberObject;
+  constexpr static const bool is_noexcept = IsNoExcept;
+  template<typename T>
+  constexpr Function_Signature(T &&) noexcept {}
+  constexpr Function_Signature() noexcept = default;
+};
 
-  template<typename Ret, typename ... Param>
-    Function_Signature(Ret (*f)(Param...)) -> Function_Signature<Ret, Function_Params<Param...>>;
+// Free functions
 
-  template<typename Ret, typename ... Param>
-    Function_Signature(Ret (*f)(Param...) noexcept) -> Function_Signature<Ret, Function_Params<Param...>, true>;
+template<typename Ret, typename... Param>
+Function_Signature(Ret (*f)(Param...))->Function_Signature<Ret, Function_Params<Param...>>;
 
-  // no reference specifier
+template<typename Ret, typename... Param>
+Function_Signature(Ret (*f)(Param...) noexcept)->Function_Signature<Ret, Function_Params<Param...>, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) volatile) -> Function_Signature<Ret, Function_Params<volatile Class &, Param...>, false, true>;
+// no reference specifier
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) volatile noexcept) -> Function_Signature<Ret, Function_Params<volatile Class &, Param...>, true, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) volatile)->Function_Signature<Ret, Function_Params<volatile Class &, Param...>, false, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) volatile const) -> Function_Signature<Ret, Function_Params<volatile const Class &, Param...>, false, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) volatile noexcept)->Function_Signature<Ret, Function_Params<volatile Class &, Param...>, true, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) volatile const noexcept) -> Function_Signature<Ret, Function_Params<volatile const Class &, Param...>, true, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) volatile const)->Function_Signature<Ret, Function_Params<volatile const Class &, Param...>, false, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) ) -> Function_Signature<Ret, Function_Params<Class &, Param...>, false, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) volatile const noexcept)->Function_Signature<Ret, Function_Params<volatile const Class &, Param...>, true, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) noexcept) -> Function_Signature<Ret, Function_Params<Class &, Param...>, true, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...))->Function_Signature<Ret, Function_Params<Class &, Param...>, false, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) const) -> Function_Signature<Ret, Function_Params<const Class &, Param...>, false, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) noexcept)->Function_Signature<Ret, Function_Params<Class &, Param...>, true, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) const noexcept) -> Function_Signature<Ret, Function_Params<const Class &, Param...>, true, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) const)->Function_Signature<Ret, Function_Params<const Class &, Param...>, false, true>;
 
-  // & reference specifier
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) const noexcept)->Function_Signature<Ret, Function_Params<const Class &, Param...>, true, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) volatile &) -> Function_Signature<Ret, Function_Params<volatile Class &, Param...>, false, true>;
+// & reference specifier
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) volatile & noexcept) -> Function_Signature<Ret, Function_Params<volatile Class &, Param...>, true, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) volatile &)->Function_Signature<Ret, Function_Params<volatile Class &, Param...>, false, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) volatile const &) -> Function_Signature<Ret, Function_Params<volatile const Class &, Param...>, false, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) volatile &noexcept)->Function_Signature<Ret, Function_Params<volatile Class &, Param...>, true, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) volatile const & noexcept) -> Function_Signature<Ret, Function_Params<volatile const Class &, Param...>, true, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) volatile const &)->Function_Signature<Ret, Function_Params<volatile const Class &, Param...>, false, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) & ) -> Function_Signature<Ret, Function_Params<Class &, Param...>, false, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) volatile const &noexcept)->Function_Signature<Ret, Function_Params<volatile const Class &, Param...>, true, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) & noexcept) -> Function_Signature<Ret, Function_Params<Class &, Param...>, true, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) &)->Function_Signature<Ret, Function_Params<Class &, Param...>, false, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) const &) -> Function_Signature<Ret, Function_Params<const Class &, Param...>, false, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) & noexcept)->Function_Signature<Ret, Function_Params<Class &, Param...>, true, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) const & noexcept) -> Function_Signature<Ret, Function_Params<const Class &, Param...>, true, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) const &)->Function_Signature<Ret, Function_Params<const Class &, Param...>, false, true>;
 
-  // && reference specifier
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) const &noexcept)->Function_Signature<Ret, Function_Params<const Class &, Param...>, true, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) volatile &&) -> Function_Signature<Ret, Function_Params<volatile Class &&, Param...>, false, true>;
+// && reference specifier
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) volatile && noexcept) -> Function_Signature<Ret, Function_Params<volatile Class &&, Param...>, true, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) volatile &&)->Function_Signature<Ret, Function_Params<volatile Class &&, Param...>, false, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) volatile const &&) -> Function_Signature<Ret, Function_Params<volatile const Class &&, Param...>, false, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) volatile &&noexcept)->Function_Signature<Ret, Function_Params<volatile Class &&, Param...>, true, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) volatile const && noexcept) -> Function_Signature<Ret, Function_Params<volatile const Class &&, Param...>, true, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) volatile const &&)->Function_Signature<Ret, Function_Params<volatile const Class &&, Param...>, false, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) &&) -> Function_Signature<Ret, Function_Params<Class &&, Param...>, false, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) volatile const &&noexcept)->Function_Signature<Ret, Function_Params<volatile const Class &&, Param...>, true, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) && noexcept) -> Function_Signature<Ret, Function_Params<Class &&, Param...>, true, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) &&)->Function_Signature<Ret, Function_Params<Class &&, Param...>, false, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) const &&) -> Function_Signature<Ret, Function_Params<const Class &&, Param...>, false, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) && noexcept)->Function_Signature<Ret, Function_Params<Class &&, Param...>, true, true>;
 
-  template<typename Ret, typename Class, typename ... Param>
-    Function_Signature(Ret (Class::*f)(Param ...) const && noexcept) -> Function_Signature<Ret, Function_Params<const Class &&, Param...>, true, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) const &&)->Function_Signature<Ret, Function_Params<const Class &&, Param...>, false, true>;
 
-  template<typename Ret, typename Class>
-    Function_Signature(Ret (Class::*f)) -> Function_Signature<Ret, Function_Params<Class &>, true, true, true>;
+template<typename Ret, typename Class, typename... Param>
+Function_Signature(Ret (Class::*f)(Param...) const &&noexcept)->Function_Signature<Ret, Function_Params<const Class &&, Param...>, true, true>;
 
-  template<typename Func>
-    Function_Signature(Func &&) -> Function_Signature<
-    typename decltype(Function_Signature{&std::decay_t<Func>::operator()})::Return_Type,
-             typename decltype(Function_Signature{&std::decay_t<Func>::operator()})::Param_Types,
-             decltype(Function_Signature{&std::decay_t<Func>::operator()})::is_noexcept,
-             false,
-             false,
-             true
-               >;
+template<typename Ret, typename Class>
+Function_Signature(Ret(Class::*f))->Function_Signature<Ret, Function_Params<Class &>, true, true, true>;
+
+// primary template handles types that have no nested ::type member:
+template<class, class = std::void_t<>>
+struct has_call_operator : std::false_type
+{
+};
+
+// specialization recognizes types that do have a nested ::type member:
+template<class T>
+struct has_call_operator<T, std::void_t<decltype(&T::operator())>> : std::true_type
+{
+};
+
+template<typename Func>
+auto function_signature(const Func &f)
+{
+  if constexpr (has_call_operator<Func>::value) {
+    return Function_Signature<
+      typename decltype(Function_Signature{ &std::decay_t<Func>::operator() })::Return_Type,
+      typename decltype(Function_Signature{ &std::decay_t<Func>::operator() })::Param_Types,
+      decltype(Function_Signature{ &std::decay_t<Func>::operator() })::is_noexcept,
+      false,
+      false,
+      true>{};
+  } else {
+    return Function_Signature{ f };
+  }
 }
+
+}// namespace chaiscript::dispatch::detail
 
 #endif

--- a/include/chaiscript/dispatchkit/proxy_functions.hpp
+++ b/include/chaiscript/dispatchkit/proxy_functions.hpp
@@ -844,7 +844,7 @@ namespace chaiscript
     namespace detail
     {
       template<typename FuncType>
-        bool types_match_except_for_arithmetic(const FuncType &t_func, const Function_Params &plist,
+        bool types_match_except_for_arithmetic(const FuncType &t_func, const chaiscript::Function_Params &plist,
             const Type_Conversions_State &t_conversions) noexcept
         {
           const std::vector<Type_Info> &types = t_func->get_param_types();
@@ -863,7 +863,7 @@ namespace chaiscript
         }
 
       template<typename InItr, typename Funcs>
-        Boxed_Value dispatch_with_conversions(InItr begin, const InItr &end, const Function_Params &plist,
+        Boxed_Value dispatch_with_conversions(InItr begin, const InItr &end, const chaiscript::Function_Params &plist,
             const Type_Conversions_State &t_conversions, const Funcs &t_funcs)
         {
           InItr matching_func(end);
@@ -919,7 +919,7 @@ namespace chaiscript
                        );
 
           try {
-            return (*(matching_func->second))(Function_Params{newplist}, t_conversions);
+            return (*(matching_func->second))(chaiscript::Function_Params{newplist}, t_conversions);
           } catch (const exception::bad_boxed_cast &) {
             //parameter failed to cast
           } catch (const exception::arity_error &) {

--- a/include/chaiscript/dispatchkit/proxy_functions.hpp
+++ b/include/chaiscript/dispatchkit/proxy_functions.hpp
@@ -77,7 +77,7 @@ namespace chaiscript
         std::vector<Boxed_Value> convert(Function_Params t_params, const Type_Conversions_State &t_conversions) const
         {
           auto vals = t_params.to_vector();
-          constexpr auto dynamic_object_type_info = user_type<Dynamic_Object>();
+          const auto dynamic_object_type_info = user_type<Dynamic_Object>();
           for (size_t i = 0; i < vals.size(); ++i)
           {
             const auto &name = m_types[i].first;
@@ -117,7 +117,7 @@ namespace chaiscript
         // second result: needs conversions
         std::pair<bool, bool> match(const Function_Params &vals, const Type_Conversions_State &t_conversions) const noexcept
         {
-          constexpr auto dynamic_object_type_info = user_type<Dynamic_Object>();
+          const auto dynamic_object_type_info = user_type<Dynamic_Object>();
           bool needs_conversion = false;
 
           if (!m_has_types) { return std::make_pair(true, needs_conversion); }
@@ -252,9 +252,9 @@ namespace chaiscript
 
         static bool compare_type_to_param(const Type_Info &ti, const Boxed_Value &bv, const Type_Conversions_State &t_conversions) noexcept
         {
-          constexpr auto boxed_value_ti = user_type<Boxed_Value>();
-          constexpr auto boxed_number_ti = user_type<Boxed_Number>();
-          constexpr auto function_ti = user_type<std::shared_ptr<const Proxy_Function_Base>>();
+          const auto boxed_value_ti = user_type<Boxed_Value>();
+          const auto boxed_number_ti = user_type<Boxed_Number>();
+          const auto function_ti = user_type<std::shared_ptr<const Proxy_Function_Base>>();
 
           if (ti.is_undef()
               || ti.bare_equal(boxed_value_ti)
@@ -757,7 +757,7 @@ namespace chaiscript
           {
             return false;
           }
-          constexpr auto class_type_info = user_type<Class>();
+          const auto class_type_info = user_type<Class>();
           return vals[0].get_type_info().bare_equal(class_type_info);
         }
 

--- a/include/chaiscript/dispatchkit/proxy_functions_detail.hpp
+++ b/include/chaiscript/dispatchkit/proxy_functions_detail.hpp
@@ -78,7 +78,7 @@ namespace chaiscript
        */
       template<typename Ret, typename ... Params>
         bool compare_types_cast(Ret (*)(Params...),
-             const Function_Params &params, const Type_Conversions_State &t_conversions) noexcept
+             const chaiscript::Function_Params &params, const Type_Conversions_State &t_conversions) noexcept
         {
           try {
             std::vector<Boxed_Value>::size_type i = 0;
@@ -93,7 +93,7 @@ namespace chaiscript
       template<typename Callable, typename Ret, typename ... Params, size_t ... I>
         Ret call_func(Ret (*)(Params...), 
                       std::index_sequence<I...>, const Callable &f,
-                      [[maybe_unused]] const Function_Params &params, 
+                      [[maybe_unused]] const chaiscript::Function_Params &params, 
                       [[maybe_unused]] const Type_Conversions_State &t_conversions)
         {
           return f(boxed_cast<Params>(params[I], &t_conversions)...);
@@ -106,7 +106,7 @@ namespace chaiscript
       /// the bad_boxed_cast is passed up to the caller.
       template<typename Callable, typename Ret, typename ... Params>
         Boxed_Value call_func(Ret (*sig)(Params...), const Callable &f,
-            const Function_Params &params, const Type_Conversions_State &t_conversions)
+            const chaiscript::Function_Params &params, const Type_Conversions_State &t_conversions)
         {
           if constexpr (std::is_same_v<Ret, void>) {
             call_func(sig, std::index_sequence_for<Params...>{}, f, params, t_conversions);

--- a/include/chaiscript/dispatchkit/register_function.hpp
+++ b/include/chaiscript/dispatchkit/register_function.hpp
@@ -87,7 +87,7 @@ namespace chaiscript
   template<typename T>
     Proxy_Function fun(T &&t)
     {
-      return dispatch::detail::make_callable(std::forward<T>(t), dispatch::detail::Function_Signature{t});
+      return dispatch::detail::make_callable(std::forward<T>(t), dispatch::detail::function_signature(t));
     }
 
 

--- a/include/chaiscript/dispatchkit/register_function.hpp
+++ b/include/chaiscript/dispatchkit/register_function.hpp
@@ -34,7 +34,8 @@ namespace chaiscript
           // we now that the Param pack will have only one element, so we are safe expanding it here
           return Proxy_Function(chaiscript::make_shared<dispatch::Proxy_Function_Base, dispatch::Attribute_Access<Ret, std::decay_t<Param>...>>(std::forward<Func>(func)));
         } else if constexpr (Is_Member) {
-          auto call = [func = std::forward<Func>(func)](auto && obj, auto && ... param) noexcept(Is_Noexcept) -> decltype(auto) {
+		  // TODO some kind of bug is preventing forwarding of this noexcept for the lambda
+          auto call = [func = std::forward<Func>(func)](auto && obj, auto && ... param) /* noexcept(Is_Noexcept) */ -> decltype(auto) {
             return (( get_first_param(Function_Params<Param...>{}, obj).*func )(std::forward<decltype(param)>(param)...));
           };
           return Proxy_Function(

--- a/include/chaiscript/dispatchkit/type_conversions.hpp
+++ b/include/chaiscript/dispatchkit/type_conversions.hpp
@@ -388,7 +388,7 @@ namespace chaiscript
       template<typename T>
         bool convertable_type() const noexcept
         {
-          constexpr auto type = user_type<T>().bare_type_info();
+          const auto type = user_type<T>().bare_type_info();
           return thread_cache().count(type) != 0;
         }
 

--- a/unittests/compiled_tests.cpp
+++ b/unittests/compiled_tests.cpp
@@ -713,15 +713,8 @@ TEST_CASE("Object copy counts")
 
   CHECK(Object_Copy_Count_Test::copycount() == 0);
   CHECK(Object_Copy_Count_Test::constructcount() == 1);
-
-
-#ifdef CHAISCRIPT_MSVC
-  CHECK(Object_Copy_Count_Test::destructcount() == 3);
-  CHECK(Object_Copy_Count_Test::movecount() == 2);
-#else
   CHECK(Object_Copy_Count_Test::destructcount() == 2);
   CHECK(Object_Copy_Count_Test::movecount() == 1);
-#endif
 }
 
 


### PR DESCRIPTION
Issue this pull request references: #536 (replaces it)

Changes proposed in this pull request

 - here I've started with @lefticus branch [`VS_2019_fixes`](https://github.com/ChaiScript/ChaiScript/tree/VS_2019_fixes), merged `develop` into it to get up to date with more recent changes, and then added several other required fixes I've discovered are necessary (discussed in my "code review" of #536). Also, the unit test "Object copy counts" now passes again without the special handling for MSVC.
