### PR TITLE
Fix typo mistake in ranged for loop

### DIFF
--- a/cheatsheet.md
+++ b/cheatsheet.md
@@ -345,7 +345,7 @@ while (some_condition()) { /* do something */ }
 
 ```
 // ranged for
-for (x : [1,2,3]) { print(i); }
+for (i : [1, 2, 3]) { print(i); }
 ```
 
 Each of the loop styles can be broken using the `break` statement. For example:


### PR DESCRIPTION
Issue this pull request references: #

Changes proposed in this pull request

 - Fix typo mistake in ranged for loop
 
