### PR TITLE
map_conversion: copy forced for loop var `p` (incompatible ref type)

### DIFF
--- a/include/chaiscript/dispatchkit/type_conversions.hpp
+++ b/include/chaiscript/dispatchkit/type_conversions.hpp
@@ -645,7 +645,7 @@ namespace chaiscript
         const std::map<std::string, Boxed_Value> &from_map = detail::Cast_Helper<const std::map<std::string, Boxed_Value> &>::cast(t_bv, nullptr);
 
         To map;
-        for (const std::pair<std::string, Boxed_Value> &p : from_map) {
+        for (const std::pair<const std::string, Boxed_Value> &p : from_map) {
           map.insert(std::make_pair(p.first, detail::Cast_Helper<typename To::mapped_type>::cast(p.second, nullptr)));
         }
 


### PR DESCRIPTION
The underlying pair that is dereferenced from the iterator has always `const` qualified `first` member (key type). Therefore, an unnecessary temporary was created and bounded to the const ref to the pair. This could be also fixed with `for (const auto &p : from_map)`.

Issue this pull request references: #

Changes proposed in this pull request

 - remove unwanted copies in a loop of the function template `Type_Conversion map_conversion()`
 
