### PR TITLE
Add include directory to chai target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,7 @@ set(CHAISCRIPT_LIBS stdlib parser)
 
 add_executable(chai src/main.cpp ${Chai_INCLUDES})
 target_link_libraries(chai ${LIBS} ${CHAISCRIPT_LIBS})
+target_include_directories(chai PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 if(BUILD_SAMPLES)
   add_executable(sanity_checks src/sanity_checks.cpp)


### PR DESCRIPTION
Add include directory to chai CMake target, this way any CMake project using chai knows the include directory automatically.
