### PR TITLE
Fix  crash with out of bounds index (issue #572)

### DIFF
--- a/include/chaiscript/dispatchkit/bootstrap_stl.hpp
+++ b/include/chaiscript/dispatchkit/bootstrap_stl.hpp
@@ -130,7 +130,7 @@ namespace chaiscript::bootstrap::standard_library {
       auto itr = container.begin();
       auto end = container.end();
 
-      if (pos < 0 || std::distance(itr, end) < (pos - 1)) {
+      if (pos < 0 || std::distance(itr, end) <= pos) {
         throw std::range_error("Cannot erase past end of range");
       }
 

--- a/unittests/vector_erase_at.chai
+++ b/unittests/vector_erase_at.chai
@@ -1,3 +1,24 @@
 auto x = [1, 2, 3]
 x.erase_at(1)
 assert_equal([1,3], x);
+
+try {
+  // We expect this to throw because of erasing an out of bounds index
+  x.erase_at(2)
+  assert_true(false)
+} catch (e) {
+  assert_true(true)
+}
+
+try {
+  // We expect this to throw because of erasing an out of bounds index
+  x.erase_at(-1)
+  assert_true(false)
+} catch (e) {
+  assert_true(true)
+}
+
+x.erase_at(0)
+assert_equal([3], x)
+x.erase_at(0)
+assert_equal([], x)

--- a/unittests/vector_insert_at.chai
+++ b/unittests/vector_insert_at.chai
@@ -1,3 +1,25 @@
 auto x = [1, 2, 3]
 x.insert_at(1, 6)
 assert_equal([1,6,2,3], x);
+
+try {
+  // We expect this to throw because of inserting an out of bounds index
+  x.insert_at(5, 55)
+  assert_true(false)
+} catch (e) {
+  assert_true(true)
+}
+
+// Inserting to the end should be allowed
+x.insert_at(4, 44)
+
+try {
+  // We expect this to throw because of inserting an out of bounds index
+  x.insert_at(-1, 111)
+  assert_true(false)
+} catch (e) {
+  assert_true(true)
+}
+
+x.insert_at(0, 100)
+assert_equal([100, 1, 6, 2, 3, 44], x)


### PR DESCRIPTION
Issue this pull request references: #572 

Changes proposed in this pull request

- the check was off by one in the wrong direction (it threw an error when `size < (pos-1)`, when it should have been `size < (pos+1)` or just `size <= pos`). Note the `erase_at` case is different from `insert_at`, where it's valid to insert at the end (at index `size`).
- update unit tests for `erase_at` and `insert_at`, to check for out of bounds cases.
 