### PR TITLE
Added virtual destructor for ChaiScript_Basic

### DIFF
--- a/include/chaiscript/language/chaiscript_engine.hpp
+++ b/include/chaiscript/language/chaiscript_engine.hpp
@@ -236,6 +236,10 @@ namespace chaiscript {
     }
 
   public:
+     
+    /// \brief Virtual destructor for ChaiScript
+    virtual ~ChaiScript_Basic() = default;
+     
     /// \brief Constructor for ChaiScript
     /// \param[in] t_lib Standard library to apply to this ChaiScript instance
     /// \param[in] t_modulepaths Vector of paths to search when attempting to load a binary module


### PR DESCRIPTION
ChaiScript inherits from ChaiScript_Basic, so this is good practice.
I also need to be able to inherit from ChaiScript and dynamic cast, which is impossible without this destructor.
 
