### PR TITLE
add support for demangling c++ type names (libstdc++)

### DIFF
--- a/include/chaiscript/dispatchkit/bootstrap.hpp
+++ b/include/chaiscript/dispatchkit/bootstrap.hpp
@@ -384,6 +384,7 @@ namespace chaiscript::bootstrap {
       m.add(fun(&Type_Info::is_arithmetic), "is_type_arithmetic");
       m.add(fun(&Type_Info::name), "cpp_name");
       m.add(fun(&Type_Info::bare_name), "cpp_bare_name");
+      m.add(fun(&Type_Info::demangled_name), "cpp_demangled_name");
       m.add(fun(&Type_Info::bare_equal), "bare_equal");
 
       basic_constructors<bool>("bool", m);

--- a/include/chaiscript/dispatchkit/dispatchkit.hpp
+++ b/include/chaiscript/dispatchkit/dispatchkit.hpp
@@ -588,7 +588,7 @@ namespace chaiscript {
           }
         }
 
-        return ti.bare_name();
+        return ti.demangled_name();
       }
 
       /// Return all registered types

--- a/include/chaiscript/dispatchkit/dispatchkit.hpp
+++ b/include/chaiscript/dispatchkit/dispatchkit.hpp
@@ -932,7 +932,7 @@ namespace chaiscript {
       void dump_system() const {
         std::cout << "Registered Types: \n";
         for (const auto &[type_name, type] : get_types()) {
-          std::cout << type_name << ": " << type.bare_name() << '\n';
+          std::cout << type_name << ": " << type.demangled_name() << '\n';
         }
 
         std::cout << '\n';

--- a/include/chaiscript/dispatchkit/type_info.hpp
+++ b/include/chaiscript/dispatchkit/type_info.hpp
@@ -15,6 +15,10 @@
 #include <type_traits>
 #include <typeinfo>
 
+#if __has_include(<cxxabi.h>)
+#include <cxxabi.h>
+#endif
+
 namespace chaiscript {
   namespace detail {
     template<typename T>
@@ -81,6 +85,24 @@ namespace chaiscript {
       } else {
         return "";
       }
+    }
+
+    std::string demangled_name() const noexcept {
+#if __has_include(<cxxabi.h>)
+      if (is_undef())
+        return "";
+
+      int status{};
+      char *ret = abi::__cxa_demangle(m_bare_type_info->name(), nullptr, nullptr, &status);
+      if (ret) {
+        std::string value{ret};
+        free(ret);
+        return value;
+      }
+      return m_bare_type_info->name();
+#else
+      return bare_name();
+#endif
     }
 
     constexpr const std::type_info *bare_type_info() const noexcept { return m_bare_type_info; }


### PR DESCRIPTION
Changes proposed in this pull request
 - add support for demangling c++ type names (libstdc++)
 - dump_system(): output demangled names for registered types
 - change get_type_name to return the demangled_name (if no broader type exists)
 
