### PR TITLE
Fix typo in `cheatsheet.md`

### DIFF
--- a/cheatsheet.md
+++ b/cheatsheet.md
@@ -46,7 +46,7 @@ chai.add(chaiscript::fun<ReturnType (ParamType1, ParamType2)>(&function_with_ove
 #### Alternative
 
 ```cpp
-chai.add(chaiscript::fun(std::static_cast<ReturnType (*)(ParamType1, ParamType2)>(&function_with_overloads)), "function_name");
+chai.add(chaiscript::fun(static_cast<ReturnType (*)(ParamType1, ParamType2)>(&function_with_overloads)), "function_name");
 ```
 This overload technique is also used when exposing base member using derived type
 


### PR DESCRIPTION
Changes proposed in this pull request

 - This PR just fixes a small typo on the section explaining how to register overloaded functions from `cheatsheet.md`.