### PR TITLE
Fix ambiguous get_pointer function

### DIFF
--- a/include/chaiscript/dispatchkit/bind_first.hpp
+++ b/include/chaiscript/dispatchkit/bind_first.hpp
@@ -42,7 +42,7 @@ namespace chaiscript
       auto bind_first(Ret (Class::*f)(Param...), O&& o)
       {
         return [f, o](Param...param) -> Ret {
-          return (get_pointer(o)->*f)(std::forward<Param>(param)...);
+          return (detail::get_pointer(o)->*f)(std::forward<Param>(param)...);
         };
       }
 
@@ -50,7 +50,7 @@ namespace chaiscript
       auto bind_first(Ret (Class::*f)(Param...) const, O&& o)
       {
         return [f, o](Param...param) -> Ret {
-          return (get_pointer(o)->*f)(std::forward<Param>(param)...);
+          return (detail::get_pointer(o)->*f)(std::forward<Param>(param)...);
         };
 
       }


### PR DESCRIPTION
When using ChaiScript in conjuction with Boost, the use of get_pointer in bind_first.hpp become ambiguous because of an existing function with the same name in Boost.
This patch simply enforces the detail namespace to avoid ambiguity.