### PR TITLE
MSVC Fix compiler warning

### DIFF
--- a/include/chaiscript/language/chaiscript_parser.hpp
+++ b/include/chaiscript/language/chaiscript_parser.hpp
@@ -2280,7 +2280,7 @@ namespace chaiscript {
               }
               build_match<eval::Dot_Access_AST_Node<Tracer>>(prev_stack_top);
             } else if (Eol()) {
-              auto start = --m_position;
+              const auto& start = --m_position;
               while (Eol()) {
               }
               if (Symbol(".")) {


### PR DESCRIPTION
MSVC2019 hints for this line: Assigning by value when a const-reference would suffice, use const auto& instead.

Issue this pull request references: None

Changes proposed in this pull request

- Modify chat script parser in order to resolve the compiler warning and to follow cpp core guidelines on the matter https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#p9-dont-waste-time-or-space
 
