### PR TITLE
Add C++20 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 cmake_policy(SET CMP0054 NEW)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # required since cmake 3.4 at least for libc++
@@ -167,7 +167,7 @@ if(MSVC)
 else()
   add_definitions(-Wall -Wextra -Wconversion -Wshadow -Wnon-virtual-dtor -Wold-style-cast -Wcast-align -Wcast-qual -Wunused -Woverloaded-virtual -Wno-noexcept-type -Wpedantic -Werror=return-type)
 
-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
     add_definitions(-Weverything -Wno-c++98-compat-pedantic  -Wno-c++98-compat -Wno-documentation -Wno-switch-enum -Wno-weak-vtables -Wno-missing-prototypes -Wno-padded -Wno-missing-noreturn -Wno-exit-time-destructors -Wno-documentation-unknown-command -Wno-unused-template -Wno-undef -Wno-double-promotion)
   else()
     add_definitions(-Wnoexcept)

--- a/unittests/compiled_tests.cpp
+++ b/unittests/compiled_tests.cpp
@@ -1032,7 +1032,7 @@ TEST_CASE("Use unique_ptr") {
   chaiscript::ChaiScript_Basic chai(create_chaiscript_stdlib(), create_chaiscript_parser());
 
   chai.add(chaiscript::fun([](int &i) { ++i; }), "inci");
-  chai.add(chaiscript::fun([](int i) { ++i; }), "copyi");
+  chai.add(chaiscript::fun([]([[maybe_unused]] int i) { ++i; }), "copyi");
   chai.add(chaiscript::fun([](int *i) { ++(*i); }), "derefi");
   chai.add(chaiscript::fun([](const std::unique_ptr<int> &i) { ++(*i); }), "constrefuniqptri");
   chai.add(chaiscript::fun([](std::unique_ptr<int> &i) { ++(*i); }), "refuniqptri");

--- a/unittests/static_chaiscript.cpp
+++ b/unittests/static_chaiscript.cpp
@@ -6,8 +6,14 @@
 /// ChaiScript as a static is unsupported with thread support enabled
 ///
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wexit-time-destructors"
+#pragma clang diagnostic ignored "-Wglobal-constructors"
+#endif
+
 #include <chaiscript/chaiscript.hpp>
 
-static chaiscript::ChaiScript chai;
+static chaiscript::ChaiScript chai{};
 
 int main() {}


### PR DESCRIPTION
ChaiScript now successfully builds on my Mac with C++20, and it passes 100% of the unit tests.

Issue this pull request references: #607

Changes proposed in this pull request

 - CMakeLists.txt: needed "Clang OR AppleClang" in one place.
 - CMakeLists.txt: C++ standard was changed from 17 to 20.
 - chaiscript_common.hpp: It had circular definitions that caused build errors related to AST_Node_Trace.
 - compiled_tests.cpp: I added [[maybe_unused]] to eliminate a minor build warning.
 - static_chaiscript.cpp: This had an annoying warning about needing to call a global destructor.
 - All of the above issues are fixed in this PR, and ChaiScript now successfully builds on my Mac with C++20, and it passes 100% of the unit tests.
 
Please merge the code and also update vcpkg, since we are using ChaiScript in our project.
