### PR TITLE
Fix several `noexcept` and `possibly dangling reference` warnings

### DIFF
--- a/include/chaiscript/dispatchkit/boxed_value.hpp
+++ b/include/chaiscript/dispatchkit/boxed_value.hpp
@@ -31,7 +31,7 @@ namespace chaiscript {
     /// structure which holds the internal state of a Boxed_Value
     /// \todo Get rid of Any and merge it with this, reducing an allocation in the process
     struct Data {
-      Data(const Type_Info &ti, chaiscript::detail::Any to, bool is_ref, const void *t_void_ptr, bool t_return_value)
+      Data(const Type_Info &ti, chaiscript::detail::Any to, bool is_ref, const void *t_void_ptr, bool t_return_value) noexcept
           : m_type_info(ti)
           , m_obj(std::move(to))
           , m_data_ptr(ti.is_const() ? nullptr : const_cast<void *>(t_void_ptr))

--- a/include/chaiscript/language/chaiscript_eval.hpp
+++ b/include/chaiscript/language/chaiscript_eval.hpp
@@ -501,13 +501,7 @@ namespace chaiscript {
       }
 
       Boxed_Value eval_internal(const chaiscript::detail::Dispatch_State &t_ss) const override {
-        const std::string &idname = [&]() -> const std::string & {
-          if (this->children[0]->identifier == AST_Node_Type::Reference) {
-            return this->children[0]->children[0]->text;
-          } else {
-            return this->children[0]->text;
-          }
-        }();
+        const std::string &idname = (this->children[0]->identifier == AST_Node_Type::Reference) ? this->children[0]->children[0]->text : this->children[0]->text;
 
         return t_ss->add_global_no_throw(Boxed_Value(), idname);
       }

--- a/src/test_module.cpp
+++ b/src/test_module.cpp
@@ -5,30 +5,30 @@
 
 class TestBaseType {
 public:
-  TestBaseType()
+  TestBaseType() noexcept
       : val(10)
       , const_val(15)
       , mdarray{} {
   }
-  TestBaseType(int)
+  TestBaseType(int) noexcept
       : val(10)
       , const_val(15)
       , mdarray{} {
   }
-  TestBaseType(int *)
+  TestBaseType(int *) noexcept
       : val(10)
       , const_val(15)
       , mdarray{} {
   }
 
-  TestBaseType(const TestBaseType &other)
+  TestBaseType(const TestBaseType &other) noexcept
       : val(other.val)
       , const_val(other.const_val)
       , const_val_ptr(&const_val)
       , func_member(other.func_member) {
   }
 
-  TestBaseType(TestBaseType &&other)
+  TestBaseType(TestBaseType &&other) noexcept
       : val(other.val)
       , const_val(other.const_val)
       , const_val_ptr(&const_val)
@@ -59,7 +59,7 @@ public:
 
 class Type2 {
 public:
-  Type2(TestBaseType t_bt)
+  Type2(TestBaseType t_bt) noexcept
       : m_bt(std::move(t_bt))
       , m_str("Hello World") {
   }


### PR DESCRIPTION
See the commits for the same info.

Using the GCC 13.3.0 I get following warnings.

Warnings for `-Wnoexcept`:

```
In file included from .../include/c++/13.3.0/bits/stl_iterator.h:85,
                 from .../include/c++/13.3.0/bits/stl_algobase.h:67,
                 from .../include/c++/13.3.0/bits/stl_tree.h:63,
                 from .../include/c++/13.3.0/map:62,
                 from .../ChaiScript/static_libs/../include/chaiscript/chaiscript_stdlib.hpp:10,
                 from .../ChaiScript/static_libs/chaiscript_stdlib.cpp:1:
.../include/c++/13.3.0/bits/stl_construct.h: In instantiation of ‘constexpr decltype (::new(void*(0)) _Tp) std::construct_at(_Tp*, _Args&& ...) [with _Tp = chaiscript::Boxed_Value::Data; _Args = {chaiscript::Type_Info, chaiscript::detail::Any, bool, std::nullptr_t, bool&}; decltype (::new(void*(0)) _Tp) = chaiscript::Boxed_Value::Data*]’:
.../include/c++/13.3.0/bits/stl_construct.h:115:21:   required from ‘constexpr void std::_Construct(_Tp*, _Args&& ...) [with _Tp = chaiscript::Boxed_Value::Data; _Args = {chaiscript::Type_Info, chaiscript::detail::Any, bool, std::nullptr_t, bool&}]’
.../include/c++/13.3.0/bits/alloc_traits.h:661:19:   required from ‘static constexpr void std::allocator_traits<std::allocator<void> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = chaiscript::Boxed_Value::Data; _Args = {chaiscript::Type_Info, chaiscript::detail::Any, bool, std::nullptr_t, bool&}; allocator_type = std::allocator<void>]’
.../include/c++/13.3.0/bits/shared_ptr_base.h:604:39:   required from ‘std::_Sp_counted_ptr_inplace<_Tp, _Alloc, _Lp>::_Sp_counted_ptr_inplace(_Alloc, _Args&& ...) [with _Args = {chaiscript::Type_Info, chaiscript::detail::Any, bool, std::nullptr_t, bool&}; _Tp = chaiscript::Boxed_Value::Data; _Alloc = std::allocator<void>; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
.../include/c++/13.3.0/bits/shared_ptr_base.h:971:16:   required from ‘std::__shared_count<_Lp>::__shared_count(_Tp*&, std::_Sp_alloc_shared_tag<_Alloc>, _Args&& ...) [with _Tp = chaiscript::Boxed_Value::Data; _Alloc = std::allocator<void>; _Args = {chaiscript::Type_Info, chaiscript::detail::Any, bool, std::nullptr_t, bool&}; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
.../include/c++/13.3.0/bits/shared_ptr_base.h:1712:14:   required from ‘std::__shared_ptr<_Tp, _Lp>::__shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {chaiscript::Type_Info, chaiscript::detail::Any, bool, std::nullptr_t, bool&}; _Tp = chaiscript::Boxed_Value::Data; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
.../include/c++/13.3.0/bits/shared_ptr.h:464:59:   required from ‘std::shared_ptr<_Tp>::shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {chaiscript::Type_Info, chaiscript::detail::Any, bool, std::nullptr_t, bool&}; _Tp = chaiscript::Boxed_Value::Data]’
.../include/c++/13.3.0/bits/shared_ptr.h:1009:14:   required from ‘std::shared_ptr<std::_NonArray<_Tp> > std::make_shared(_Args&& ...) [with _Tp = chaiscript::Boxed_Value::Data; _Args = {chaiscript::Type_Info, chaiscript::detail::Any, bool, std::nullptr_t, bool&}; _NonArray<_Tp> = chaiscript::Boxed_Value::Data]’
.../ChaiScript/static_libs/../include/chaiscript/language/../dispatchkit/boxed_value.hpp:74:38:   required from here
.../include/c++/13.3.0/bits/stl_construct.h:95:14: warning: noexcept-expression evaluates to ‘false’ because of a call to ‘chaiscript::Boxed_Value::Data::Data(const chaiscript::Type_Info&, chaiscript::detail::Any, bool, const void*, bool)’ [-Wnoexcept]
   95 |     noexcept(noexcept(::new((void*)0) _Tp(std::declval<_Args>()...)))
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from .../ChaiScript/static_libs/../include/chaiscript/language/chaiscript_common.hpp:21,
                 from .../ChaiScript/static_libs/../include/chaiscript/chaiscript_stdlib.hpp:17:
.../ChaiScript/static_libs/../include/chaiscript/language/../dispatchkit/boxed_value.hpp:34:7: note: but ‘chaiscript::Boxed_Value::Data::Data(const chaiscript::Type_Info&, chaiscript::detail::Any, bool, const void*, bool)’ does not throw; perhaps it should be declared ‘noexcept’
   34 |       Data(const Type_Info &ti, chaiscript::detail::Any to, bool is_ref, const void *t_void_ptr, bool t_return_value)
      |       ^~~~
```
and similar to
```
In file included from .../include/c++/13.3.0/bits/char_traits.h:57,
                 from .../include/c++/13.3.0/string_view:40,
                 from .../ChaiScript/include/chaiscript/chaiscript_defines.hpp:23,
                 from .../ChaiScript/include/chaiscript/chaiscript_basic.hpp:10,
                 from .../ChaiScript/src/test_module.cpp:2:
.../include/c++/13.3.0/bits/stl_construct.h: In instantiation of ‘constexpr decltype (::new(void*(0)) _Tp) std::construct_at(_Tp*, _Args&& ...) [with _Tp = Type2; _Args = {Type2}; decltype (::new(void*(0)) _Tp) = Type2*]’:
.../include/c++/13.3.0/bits/stl_construct.h:115:21:   required from ‘constexpr void std::_Construct(_Tp*, _Args&& ...) [with _Tp = Type2; _Args = {Type2}]’
.../include/c++/13.3.0/bits/alloc_traits.h:661:19:   required from ‘static constexpr void std::allocator_traits<std::allocator<void> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = Type2; _Args = {Type2}; allocator_type = std::allocator<void>]’
.../include/c++/13.3.0/bits/shared_ptr_base.h:604:39:   required from ‘std::_Sp_counted_ptr_inplace<_Tp, _Alloc, _Lp>::_Sp_counted_ptr_inplace(_Alloc, _Args&& ...) [with _Args = {Type2}; _Tp = Type2; _Alloc = std::allocator<void>; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
.../include/c++/13.3.0/bits/shared_ptr_base.h:971:16:   required from ‘std::__shared_count<_Lp>::__shared_count(_Tp*&, std::_Sp_alloc_shared_tag<_Alloc>, _Args&& ...) [with _Tp = Type2; _Alloc = std::allocator<void>; _Args = {Type2}; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
.../include/c++/13.3.0/bits/shared_ptr_base.h:1712:14:   required from ‘std::__shared_ptr<_Tp, _Lp>::__shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {Type2}; _Tp = Type2; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
.../include/c++/13.3.0/bits/shared_ptr.h:464:59:   required from ‘std::shared_ptr<_Tp>::shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {Type2}; _Tp = Type2]’
.../include/c++/13.3.0/bits/shared_ptr.h:1009:14:   required from ‘std::shared_ptr<std::_NonArray<_Tp> > std::make_shared(_Args&& ...) [with _Tp = Type2; _Args = {Type2}; _NonArray<_Tp> = Type2]’
.../ChaiScript/include/chaiscript/dispatchkit/boxed_value.hpp:121:37:   required from ‘static auto chaiscript::Boxed_Value::Object_Data::get(T, bool) [with T = Type2]’
.../ChaiScript/include/chaiscript/dispatchkit/boxed_value.hpp:133:34:   required from ‘chaiscript::Boxed_Value::Boxed_Value(T&&, bool) [with T = Type2; <template-parameter-1-2> = void]’
.../ChaiScript/include/chaiscript/dispatchkit/type_conversions.hpp:480:26:   required from ‘chaiscript::Type_Conversion chaiscript::type_conversion(const Callable&) [with From = TestBaseType; To = Type2; Callable = create_chaiscript_module_test_module()::<lambda(const TestBaseType&)>; Type_Conversion = std::shared_ptr<detail::Type_Conversion_Base>]’
.../ChaiScript/src/test_module.cpp:194:58:   required from here
.../include/c++/13.3.0/bits/stl_construct.h:95:14: warning: noexcept-expression evaluates to ‘false’ because of a call to ‘Type2::Type2(Type2&&)’ [-Wnoexcept]
   95 |     noexcept(noexcept(::new((void*)0) _Tp(std::declval<_Args>()...)))
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.../ChaiScript/src/test_module.cpp:60:7: note: but ‘Type2::Type2(Type2&&)’ does not throw; perhaps it should be declared ‘noexcept’
   60 | class Type2 {
      |       ^~~~~
```

Also fix a `possibly dangling reference` warning by replacing a lambda with a simple ternary expression.

```
In file included from .../ChaiScript/static_libs/../include/chaiscript/language/chaiscript_optimizer.hpp:10,
                 from .../ChaiScript/static_libs/../include/chaiscript/language/chaiscript_parser.hpp:26,
                 from .../ChaiScript/static_libs/chaiscript_parser.cpp:1:
.../ChaiScript/static_libs/../include/chaiscript/language/chaiscript_eval.hpp: In instantiation of ‘chaiscript::Boxed_Value chaiscript::eval::Global_Decl_AST_Node<T>::eval_internal(const chaiscript::detail::Dispatch_State&) const [with T = chaiscript::eval::Tracer<chaiscript::eval::Noop_Tracer_Detail>]’:
.../ChaiScript/static_libs/../include/chaiscript/language/chaiscript_eval.hpp:503:19:   required from here
.../ChaiScript/static_libs/../include/chaiscript/language/chaiscript_eval.hpp:504:28: warning: possibly dangling reference to a temporary [-Wdangling-reference]
  504 |         const std::string &idname = [&]() -> const std::string & {
      |                            ^~~~~~
.../ChaiScript/static_libs/../include/chaiscript/language/chaiscript_eval.hpp:510:10: note: the temporary was destroyed at the end of the full expression ‘<lambda closure object>chaiscript::eval::Global_Decl_AST_Node<chaiscript::eval::Tracer<chaiscript::eval::Noop_Tracer_Detail> >::eval_internal(const chaiscript::detail::Dispatch_State&) const::<lambda()>{((const chaiscript::eval::Global_Decl_AST_Node<chaiscript::eval::Tracer<chaiscript::eval::Noop_Tracer_Detail> >*)this)}.chaiscript::eval::Global_Decl_AST_Node<chaiscript::eval::Tracer<chaiscript::eval::Noop_Tracer_Detail> >::eval_internal(const chaiscript::detail::Dispatch_State&) const::<lambda()>()’
  504 |         const std::string &idname = [&]() -> const std::string & {
      |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  505 |           if (this->children[0]->identifier == AST_Node_Type::Reference) {
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  506 |             return this->children[0]->children[0]->text;
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  507 |           } else {
      |           ~~~~~~~~
  508 |             return this->children[0]->text;
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  509 |           }
      |           ~
  510 |         }();
      |         ~^~
```