### PR TITLE
Fix #592: Potential bug: Local variable saw_eol in Class_Statements() in chaiscript_parser.hpp apparently always true

### DIFF
--- a/include/chaiscript/language/chaiscript_parser.hpp
+++ b/include/chaiscript/language/chaiscript_parser.hpp
@@ -2736,7 +2736,7 @@ namespace chaiscript {
 
         while (has_more) {
           const auto start = m_position;
-          if (Def(true, t_class_name) || Var_Decl(true, t_class_name)) {
+          if (Def(true, t_class_name)) {
             if (!saw_eol) {
               throw exception::eval_error("Two function definitions missing line separator",
                                           File_Position(start.line, start.col),
@@ -2745,6 +2745,15 @@ namespace chaiscript {
             has_more = true;
             retval = true;
             saw_eol = true;
+          } else if (Var_Decl(true, t_class_name)) {
+            if (!saw_eol) {
+              throw exception::eval_error("Two expressions missing line separator",
+                                          File_Position(start.line, start.col),
+                                          *m_filename);
+            }
+            has_more = true;
+            retval = true;
+            saw_eol = false;
           } else if (Eol()) {
             has_more = true;
             retval = true;

--- a/unittests/class_missing_line_separator.chai
+++ b/unittests/class_missing_line_separator.chai
@@ -1,0 +1,23 @@
+
+// Test that two var declarations on the same line in a class body
+// are rejected with a "missing line separator" error (issue #592)
+
+try {
+  eval("class Foo { var x var y }")
+  assert_true(false)
+} catch (eval_error) {
+}
+
+// Also verify that properly separated declarations still work
+class Bar {
+  var x
+  var y
+  def Bar() {
+    this.x = 1
+    this.y = 2
+  }
+}
+
+auto b = Bar()
+assert_equal(1, b.x)
+assert_equal(2, b.y)


### PR DESCRIPTION
Automated fix by @leftibot.

### What changed

> Fix #592: Local variable saw_eol in Class_Statements() was always true
> The saw_eol variable in Class_Statements() was initialized to true and
> only ever set back to true, making the "missing line separator" check
> unreachable. The fix separates Def (block statement ending with }) from
> Var_Decl (simple statement) so that Var_Decl sets saw_eol to false,
> matching the pattern used in Statements() for simple expressions.
> Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

### Files
```
 include/chaiscript/language/chaiscript_parser.hpp | 11 ++++++++++-
 unittests/class_missing_line_separator.chai       | 23 +++++++++++++++++++++++
 2 files changed, 33 insertions(+), 1 deletion(-)
```

Closes #592

_Triggered by @lefticus._