### PR TITLE
Fix #607: Unable to build in C++20 on Mac

### DIFF
--- a/include/chaiscript/language/chaiscript_common.hpp
+++ b/include/chaiscript/language/chaiscript_common.hpp
@@ -26,10 +26,6 @@
 
 namespace chaiscript {
   struct AST_Node;
-  struct AST_Node_Trace;
-  namespace exception {
-    struct eval_error;
-  }
 } // namespace chaiscript
 
 namespace chaiscript {

--- a/unittests/compiled_tests.cpp
+++ b/unittests/compiled_tests.cpp
@@ -1436,3 +1436,23 @@ TEST_CASE("Issue #421 - Switch with type_conversion does not compare destroyed o
     result
   })") == 0);
 }
+
+// Regression test for issue #607: AST_Node_Trace must be a complete type
+// when used in eval_error's std::vector<AST_Node_Trace> call_stack member.
+// This failed to compile with C++20 on clang/libc++ when AST_Node_Trace
+// was only forward-declared before eval_error's definition.
+TEST_CASE("eval_error with AST_Node_Trace call stack compiles in C++20") {
+  chaiscript::ChaiScript_Basic chai(create_chaiscript_stdlib(), create_chaiscript_parser());
+
+  // Trigger an eval_error by calling a non-existent function
+  try {
+    chai.eval("nonexistent_function()");
+    REQUIRE(false);
+  } catch (const chaiscript::exception::eval_error &e) {
+    // Verify that eval_error's call_stack member (std::vector<AST_Node_Trace>)
+    // is usable - this would fail to compile if AST_Node_Trace were incomplete
+    const auto &stack = e.call_stack;
+    CHECK(e.pretty_print().size() > 0);
+    (void)stack;
+  }
+}


### PR DESCRIPTION
Automated fix by @leftibot.

### What changed

> Fix #607: Remove unnecessary forward declarations that cause C++20 build failures
> The forward declarations of AST_Node_Trace and eval_error at the top of
> chaiscript_common.hpp introduced these types as incomplete before the standard
> library headers were fully processed. On clang/libc++ in C++20 mode, this
> caused compilation errors because std::vector<AST_Node_Trace> was instantiated
> while the type was still incomplete. Since the full definitions of both types
> appear later in the same file (and nothing between the forward declarations
> and the definitions references them), these forward declarations are unnecessary
> and removing them prevents the incomplete type issue.
> Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

### Files
```
 include/chaiscript/language/chaiscript_common.hpp |  4 ----
 unittests/compiled_tests.cpp                      | 20 ++++++++++++++++++++
 2 files changed, 20 insertions(+), 4 deletions(-)
```

Closes #607

_Triggered by @lefticus._