### PR TITLE
Fix #594: Memory issue with Map keys and Vector.push_back()

### DIFF
--- a/include/chaiscript/dispatchkit/handle_return.hpp
+++ b/include/chaiscript/dispatchkit/handle_return.hpp
@@ -126,7 +126,7 @@ namespace chaiscript {
       struct Handle_Return_Ref {
         template<typename T>
         static Boxed_Value handle(T &&r) {
-          return Boxed_Value(std::cref(r), true);
+          return Boxed_Value(std::cref(r), false);
         }
       };
 

--- a/unittests/map_keys_vector_push_back.chai
+++ b/unittests/map_keys_vector_push_back.chai
@@ -1,0 +1,29 @@
+// Regression test for issue #594
+// Map keys pushed into a vector via .first should remain valid
+// after the map goes out of scope.
+
+def keys(Map map)
+{
+  var v = Vector();
+  for( i : map )
+  {
+    v.push_back(i.first);
+  }
+  return v;
+}
+
+var k = Vector();
+if ( true )
+{
+  var m = ["a":"x", "b":"y", "c":"z"];
+  k = keys(m);
+}
+
+// After the map is out of scope, the keys should still be valid strings
+assert_equal(3, k.size())
+
+// Verify each element is a non-empty string
+for (elem : k)
+{
+  assert_true(elem.size() > 0)
+}


### PR DESCRIPTION
Automated fix by @leftibot.

### What changed

> Fix #594: Map keys become dangling references when pushed into Vector
> The Handle_Return_Ref specialization for const references was wrapping
> return values in std::cref() while marking them as return values
> (is_return_value=true). This caused Vector.push_back() to store the
> reference directly without cloning, since it assumes return values are
> freshly created temporaries. When the source object (e.g., a map) went
> out of scope, the vector contained dangling references to freed memory.
> The fix sets is_return_value=false for const reference returns, which
> correctly triggers push_back to clone the value instead of storing a
> bare reference. This is consistent with the non-const reference handler
> (Handle_Return<Ret &>) which also does not set the return value flag.
> Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

### Files
```
 include/chaiscript/dispatchkit/handle_return.hpp |  2 +-
 unittests/map_keys_vector_push_back.chai         | 29 ++++++++++++++++++++++++
 2 files changed, 30 insertions(+), 1 deletion(-)
```

Closes #594

_Triggered by @lefticus._