### PR TITLE
[WIP] Issue #631 — respecting CMake's CMAKE_INSTALL_PREFIX for installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ configure_file(Doxyfile.in ${CMAKE_BINARY_DIR}/Doxyfile)
 
 include(CTest)
 include(CPack)
+include(GNUInstallDirs)
 include(cmake/Catch.cmake)
 
 if(NOT MINGW)
@@ -448,4 +449,10 @@ configure_file(contrib/pkgconfig/chaiscript.pc.in lib/pkgconfig/chaiscript.pc @O
 install(FILES "${chaiscript_BINARY_DIR}/lib/pkgconfig/chaiscript.pc"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
-    
+add_test(NAME pkgconfig_prefix_test
+  COMMAND ${CMAKE_COMMAND}
+    -DPC_FILE=${chaiscript_BINARY_DIR}/lib/pkgconfig/chaiscript.pc
+    -DEXPECTED_PREFIX=${CMAKE_INSTALL_PREFIX}
+    -DEXPECTED_LIBDIR=${CMAKE_INSTALL_LIBDIR}
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/check_pkgconfig.cmake)
+

--- a/cmake/check_pkgconfig.cmake
+++ b/cmake/check_pkgconfig.cmake
@@ -1,0 +1,32 @@
+# Verify the generated chaiscript.pc has correct prefix and libdir values.
+# This test catches issues where CMAKE_INSTALL_PREFIX or CMAKE_INSTALL_LIBDIR
+# are not properly respected in the pkg-config file.
+
+file(READ "${PC_FILE}" PC_CONTENT)
+
+# Check that prefix matches CMAKE_INSTALL_PREFIX
+string(REGEX MATCH "prefix=([^\n]*)" PREFIX_MATCH "${PC_CONTENT}")
+set(ACTUAL_PREFIX "${CMAKE_MATCH_1}")
+
+if(NOT ACTUAL_PREFIX STREQUAL EXPECTED_PREFIX)
+  message(FATAL_ERROR
+    "pkgconfig prefix mismatch:\n"
+    "  expected: '${EXPECTED_PREFIX}'\n"
+    "  actual:   '${ACTUAL_PREFIX}'\n"
+    "CMAKE_INSTALL_PREFIX is not being respected in chaiscript.pc")
+endif()
+
+# Check that libdir uses the correct lib directory name
+string(REGEX MATCH "libdir=([^\n]*)" LIBDIR_MATCH "${PC_CONTENT}")
+set(ACTUAL_LIBDIR "${CMAKE_MATCH_1}")
+
+set(EXPECTED_LIBDIR_VALUE "\${exec_prefix}/${EXPECTED_LIBDIR}")
+if(NOT ACTUAL_LIBDIR STREQUAL EXPECTED_LIBDIR_VALUE)
+  message(FATAL_ERROR
+    "pkgconfig libdir mismatch:\n"
+    "  expected: '${EXPECTED_LIBDIR_VALUE}'\n"
+    "  actual:   '${ACTUAL_LIBDIR}'\n"
+    "CMAKE_INSTALL_LIBDIR is not being respected in chaiscript.pc")
+endif()
+
+message(STATUS "pkgconfig check passed: prefix='${ACTUAL_PREFIX}', libdir='${ACTUAL_LIBDIR}'")

--- a/contrib/pkgconfig/chaiscript.pc.in
+++ b/contrib/pkgconfig/chaiscript.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
-includedir=${prefix}/include
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: chaiscript
 Description: ChaiScript is a scripting language that easily embeds into your existing C++ applications. It's built to be flexible and dynamic, yet still maintain the type-safety you expect as a C++ user. It can natively use classes, methods, and attributes, even if the class inherits functionality from a parent class. 


### PR DESCRIPTION
Automated attempt by @leftibot. Opening as **draft** — verification failed.

**Reason:** no test files were detected in the diff

### What changed

> Fix #631: Respect CMAKE_INSTALL_PREFIX and use GNUInstallDirs for install paths
> The CMakeLists.txt used CMAKE_INSTALL_LIBDIR in install destinations without
> including the GNUInstallDirs module, leaving the variable empty. This caused
> libraries to install to absolute paths like /chaiscript instead of lib/chaiscript,
> and the pkg-config file to install to /pkgconfig instead of lib/pkgconfig. The
> chaiscript.pc.in template also hardcoded "lib" and "include" instead of using
> the CMake variables. Added include(GNUInstallDirs) and updated the .pc.in
> template to use @CMAKE_INSTALL_LIBDIR@ and @CMAKE_INSTALL_INCLUDEDIR@.
> Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

### Files
```
 CMakeLists.txt                     |  9 ++++++++-
 cmake/check_pkgconfig.cmake        | 32 ++++++++++++++++++++++++++++++++
 contrib/pkgconfig/chaiscript.pc.in |  4 ++--
 3 files changed, 42 insertions(+), 3 deletions(-)
```

Will close #631 once finalized.

_Triggered by @lefticus._