### PR TITLE
Fix #459: char, to_char, int, to_int, string, to_string

### DIFF
--- a/include/chaiscript/dispatchkit/bootstrap.hpp
+++ b/include/chaiscript/dispatchkit/bootstrap.hpp
@@ -115,6 +115,8 @@ namespace chaiscript::bootstrap {
 
     m.add(fun(&parse_string<T>), "to_" + name);
     m.add(fun([](const T t) { return t; }), "to_" + name);
+    m.add(fun([](const Boxed_Number &bn) { return bn.get_as<T>(); }), "to_" + name);
+    m.add(fun(&parse_string<T>), name);
   }
 
   /// "clone" function for a shared_ptr type. This is used in the case

--- a/unittests/conversion_functions.chai
+++ b/unittests/conversion_functions.chai
@@ -1,0 +1,33 @@
+// Test that all conversion functions work across char, int, and string types
+
+// char() constructor
+assert_equal('A', char('A'))   // char from char (identity via Boxed_Number)
+assert_equal('A', char(65))    // char from int (via Boxed_Number)
+assert_equal('A', char("A"))   // char from string (new)
+
+// to_char() conversions
+assert_equal('A', to_char('A'))   // to_char from char (identity)
+assert_equal('A', to_char(65))    // to_char from int (new, via Boxed_Number)
+assert_equal('A', to_char("A"))   // to_char from string (existing)
+
+// int() constructor
+assert_equal(65, int('A'))   // int from char (via Boxed_Number)
+assert_equal(65, int(65))    // int from int (identity via Boxed_Number)
+assert_equal(65, int("65"))  // int from string (new)
+
+// to_int() conversions
+assert_equal(65, to_int('A'))    // to_int from char (new, via Boxed_Number)
+assert_equal(65, to_int(65))     // to_int from int (identity)
+assert_equal(65, to_int("65"))   // to_int from string (existing)
+
+// to_string() conversions
+assert_equal("A", to_string('A'))
+assert_equal("65", to_string(65))
+assert_equal("A", to_string("A"))
+
+// double conversions
+assert_equal(3.5, double("3.5"))       // double from string (new)
+assert_equal(3.5, to_double("3.5"))    // to_double from string (existing)
+assert_equal(65.0, to_double('A'))     // to_double from char (new, via Boxed_Number)
+assert_equal(65.0, to_double(65))      // to_double from int (new, via Boxed_Number)
+assert_equal("3.5", to_string(3.5))    // to_string from double (existing)


### PR DESCRIPTION
Automated fix by @leftibot.

### What changed

> Fix #459: Fill out the set of conversion functions for all POD types
> Previously, to_<type> only accepted a string or the same type (identity),
> and <type>() constructors only accepted Boxed_Number. This left gaps such as
> to_int(char), to_char(int), char(string), int(string), and to_double(char).
> Add two overloads to bootstrap_pod_type: to_<name>(Boxed_Number) enables
> cross-type numeric conversions (e.g. to_int('A') → 65, to_char(65) → 'A'),
> and <name>(string) via parse_string enables construction from strings
> (e.g. char("A") → 'A', int("65") → 65, double("3.5") → 3.5).
> Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

### Files
```
 include/chaiscript/dispatchkit/bootstrap.hpp |  2 ++
 unittests/conversion_functions.chai          | 33 ++++++++++++++++++++++++++++
 2 files changed, 35 insertions(+)
```

Closes #459

_Triggered by @lefticus._