### PR TITLE
Fix #473: Variable Assignment and Return `return foo = 5`

### DIFF
--- a/include/chaiscript/language/chaiscript_parser.hpp
+++ b/include/chaiscript/language/chaiscript_parser.hpp
@@ -2282,7 +2282,7 @@ namespace chaiscript {
         const auto prev_stack_top = m_match_stack.size();
 
         if (Keyword("return")) {
-          Operator();
+          Equation();
           build_match<eval::Return_AST_Node<Tracer>>(prev_stack_top);
           return true;
         } else {

--- a/unittests/return_assignment.chai
+++ b/unittests/return_assignment.chai
@@ -1,0 +1,16 @@
+// Test that assignment expressions work inside return statements
+// Issue #473: `return foo = 5` should work
+
+def return_assign() {
+  var x = 0
+  return x = 5
+}
+
+assert_equal(5, return_assign())
+
+def return_member_assign() {
+  var o = Dynamic_Object()
+  return o.value = 42
+}
+
+assert_equal(42, return_member_assign())


### PR DESCRIPTION
Automated fix by @leftibot.

### What changed

> Fix #473: Allow assignment expressions in return statements
> The Return() parser function called Operator() to parse the return value,
> which only handles arithmetic/logical operators but not assignments. Changed
> it to call Equation(), which wraps Operator() and adds assignment parsing.
> This is consistent with how If, For, and function argument parsing already
> work. Enables `return foo = 5`, `return x += 1`, etc.
> Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

### Files
```
 include/chaiscript/language/chaiscript_parser.hpp |  2 +-
 unittests/return_assignment.chai                  | 16 ++++++++++++++++
 2 files changed, 17 insertions(+), 1 deletion(-)
```

Closes #473

_Triggered by @lefticus._