### PR TITLE
Fix #633: [Bug] Stack-overflow due to infinite recursion in user-defined operator (string interpolation)

### DIFF
--- a/include/chaiscript/chaiscript_defines.hpp
+++ b/include/chaiscript/chaiscript_defines.hpp
@@ -79,8 +79,18 @@ static_assert(_MSC_FULL_VER >= 190024210, "Visual C++ 2015 Update 3 or later req
 // causes the dispatcher to throw chaiscript::exception::stack_overflow_error
 // instead of letting the native call stack overflow. Defining the macro on
 // the command line overrides the default.
+//
+// MSVC Debug builds emit very large per-frame native stack usage (no inlining,
+// /RTC, buffer security checks) and Windows defaults to a 1 MiB thread stack,
+// so the same ChaiScript depth that fits comfortably on Linux/macOS or in an
+// MSVC Release build overflows the native stack before the depth check fires.
+// We pick a tighter default in that configuration to keep the throw reachable.
 #ifndef CHAISCRIPT_MAX_CALL_DEPTH
+#if defined(CHAISCRIPT_MSVC) && defined(_DEBUG)
+#define CHAISCRIPT_MAX_CALL_DEPTH 32
+#else
 #define CHAISCRIPT_MAX_CALL_DEPTH 256
+#endif
 #endif
 
 #include <cmath>

--- a/include/chaiscript/chaiscript_defines.hpp
+++ b/include/chaiscript/chaiscript_defines.hpp
@@ -75,6 +75,14 @@ static_assert(_MSC_FULL_VER >= 190024210, "Visual C++ 2015 Update 3 or later req
 #define CHAISCRIPT_DEBUG false
 #endif
 
+// Upper bound on the depth of nested ChaiScript function calls. Hitting it
+// causes the dispatcher to throw chaiscript::exception::stack_overflow_error
+// instead of letting the native call stack overflow. Defining the macro on
+// the command line overrides the default.
+#ifndef CHAISCRIPT_MAX_CALL_DEPTH
+#define CHAISCRIPT_MAX_CALL_DEPTH 256
+#endif
+
 #include <cmath>
 #include <memory>
 #include <string>
@@ -87,6 +95,9 @@ namespace chaiscript {
   constexpr static const char *compiler_version = CHAISCRIPT_COMPILER_VERSION;
   constexpr static const char *compiler_name = CHAISCRIPT_COMPILER_NAME;
   constexpr static const bool debug_build = CHAISCRIPT_DEBUG;
+
+  constexpr static const int max_call_depth = CHAISCRIPT_MAX_CALL_DEPTH;
+  static_assert(max_call_depth > 0, "CHAISCRIPT_MAX_CALL_DEPTH must be a positive integer");
 
   template<typename B, typename D, typename... Arg>
   inline std::shared_ptr<B> make_shared(Arg &&...arg) {

--- a/include/chaiscript/chaiscript_defines.hpp
+++ b/include/chaiscript/chaiscript_defines.hpp
@@ -70,9 +70,9 @@ static_assert(_MSC_FULL_VER >= 190024210, "Visual C++ 2015 Update 3 or later req
 #endif
 
 #ifdef _DEBUG
-#define CHAISCRIPT_DEBUG 1
+#define CHAISCRIPT_DEBUG true
 #else
-#define CHAISCRIPT_DEBUG 0
+#define CHAISCRIPT_DEBUG false
 #endif
 
 // Upper bound on the depth of nested ChaiScript function calls. Hitting it

--- a/include/chaiscript/chaiscript_defines.hpp
+++ b/include/chaiscript/chaiscript_defines.hpp
@@ -70,9 +70,9 @@ static_assert(_MSC_FULL_VER >= 190024210, "Visual C++ 2015 Update 3 or later req
 #endif
 
 #ifdef _DEBUG
-#define CHAISCRIPT_DEBUG true
+#define CHAISCRIPT_DEBUG 1
 #else
-#define CHAISCRIPT_DEBUG false
+#define CHAISCRIPT_DEBUG 0
 #endif
 
 // Upper bound on the depth of nested ChaiScript function calls. Hitting it
@@ -86,7 +86,7 @@ static_assert(_MSC_FULL_VER >= 190024210, "Visual C++ 2015 Update 3 or later req
 // MSVC Release build overflows the native stack before the depth check fires.
 // We pick a tighter default in that configuration to keep the throw reachable.
 #ifndef CHAISCRIPT_MAX_CALL_DEPTH
-#if defined(CHAISCRIPT_MSVC) && defined(_DEBUG)
+#if defined(CHAISCRIPT_MSVC) && CHAISCRIPT_DEBUG
 #define CHAISCRIPT_MAX_CALL_DEPTH 32
 #else
 #define CHAISCRIPT_MAX_CALL_DEPTH 256

--- a/include/chaiscript/dispatchkit/dispatchkit.hpp
+++ b/include/chaiscript/dispatchkit/dispatchkit.hpp
@@ -121,6 +121,19 @@ namespace chaiscript {
       global_non_const(const global_non_const &) = default;
       ~global_non_const() noexcept override = default;
     };
+
+    /// Exception thrown when the ChaiScript call stack exceeds
+    /// chaiscript::max_call_depth, signalling runaway recursion before the
+    /// native stack can overflow.
+    class stack_overflow_error : public std::runtime_error {
+    public:
+      stack_overflow_error() noexcept
+          : std::runtime_error("Maximum call stack depth exceeded") {
+      }
+
+      stack_overflow_error(const stack_overflow_error &) = default;
+      ~stack_overflow_error() noexcept override = default;
+    };
   } // namespace exception
 
   /// \brief Holds a collection of ChaiScript settings which can be applied to the ChaiScript runtime.
@@ -1010,6 +1023,10 @@ namespace chaiscript {
       void save_function_params(const Function_Params &t_params) { save_function_params(*m_stack_holder, t_params); }
 
       void new_function_call(Stack_Holder &t_s, Type_Conversions::Conversion_Saves &t_saves) {
+        if (t_s.call_depth >= max_call_depth) {
+          throw chaiscript::exception::stack_overflow_error{};
+        }
+
         if (t_s.call_depth == 0) {
           m_conversions.enable_conversion_saves(t_saves, true);
         }

--- a/unittests/recursion_depth_protection.chai
+++ b/unittests/recursion_depth_protection.chai
@@ -30,10 +30,12 @@ assert_true(caught)
 // distinguish it from an arbitrary script-level error.
 assert_true(find(message, "call stack") != -1)
 
-// A bounded recursion that stays below the limit must keep working.
+// A bounded recursion that stays well below the limit must keep working.
+// Use a small depth so the test passes on every platform default - notably
+// the MSVC Debug build where the native stack budget forces a tighter cap.
 def count_down(n) {
   if (n <= 0) { return 0 }
   return count_down(n - 1) + 1
 }
 
-assert_equal(50, count_down(50))
+assert_equal(10, count_down(10))

--- a/unittests/recursion_depth_protection.chai
+++ b/unittests/recursion_depth_protection.chai
@@ -1,0 +1,39 @@
+// Regression test for issue #633: Stack-overflow due to infinite recursion
+// in user-defined operator (string interpolation).
+//
+// Before the fix the recursive `/=` invocation triggered unbounded native
+// recursion in the evaluator and crashed the host process with a SIGSEGV.
+// The engine now bounds call_depth and throws a catchable exception
+// instead of letting the native stack overflow.
+
+def string::`/=`(double d) {
+  this = "${this/= 2}/=${d}";
+  return this;
+}
+
+var s = "o World"
+var caught = false
+var message = ""
+
+try {
+  s /= 2
+  // unreachable: the recursive operator must abort with an exception
+  assert_true(false)
+} catch (e) {
+  caught = true
+  message = e.what()
+}
+
+assert_true(caught)
+
+// The reported error must mention the call-stack overflow so users can
+// distinguish it from an arbitrary script-level error.
+assert_true(find(message, "call stack") != -1)
+
+// A bounded recursion that stays below the limit must keep working.
+def count_down(n) {
+  if (n <= 0) { return 0 }
+  return count_down(n - 1) + 1
+}
+
+assert_equal(50, count_down(50))


### PR DESCRIPTION
Automated fix by @leftibot.

### What changed

> Fix #633: Bound ChaiScript call stack to prevent native stack overflow
> Recursive user-defined operators (e.g. a `string::/=` whose body calls
> itself through string interpolation) drove the AST evaluator into
> unbounded native recursion and crashed the host process with SIGSEGV.
> The dispatcher now refuses to enter a new function frame once
> `Stack_Holder::call_depth` reaches `chaiscript::max_call_depth`
> (default 256, overridable via the `CHAISCRIPT_MAX_CALL_DEPTH` macro)
> and throws the new `chaiscript::exception::stack_overflow_error`
> instead, letting both ChaiScript-level `try`/`catch` and C++ hosts
> recover from runaway recursion.
> Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

### Files
```
 include/chaiscript/chaiscript_defines.hpp      | 11 ++++++++
 include/chaiscript/dispatchkit/dispatchkit.hpp | 17 +++++++++++
 unittests/recursion_depth_protection.chai      | 39 ++++++++++++++++++++++++++
 3 files changed, 67 insertions(+)
```

Closes #633

_Triggered by @lefticus._